### PR TITLE
Replace unsafe id generator with nanoid

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+POSTGRES_PRISMA_URL=postgresql://postgres:1234@localhost
+POSTGRES_URL_NON_POOLING=postgresql://postgres:1234@localhost
+NEXT_PUBLIC_BASE_URL=http://localhost:3000

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.0.0",
         "lucide-react": "^0.290.0",
+        "nanoid": "^5.0.4",
         "next": "^14.0.4",
         "next-plausible": "^3.12.0",
         "next-themes": "^0.2.1",
@@ -4173,21 +4174,20 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.4.tgz",
+      "integrity": "sha512-vAjmBf13gsmhXSgBrtIclinISzFFy22WwCYoyilZlsrRXNIHSwgFQ1bEdjRwMT3aoadeIF6HMuDRlOxzfXV8ig==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "bin": {
-        "nanoid": "bin/nanoid.cjs"
+        "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+        "node": "^18 || >=20"
       }
     },
     "node_modules/natural-compare": {
@@ -4832,6 +4832,23 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/postgres-array": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
     "lucide-react": "^0.290.0",
+    "nanoid": "^5.0.4",
     "next": "^14.0.4",
     "next-plausible": "^3.12.0",
     "next-themes": "^0.2.1",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,9 +1,10 @@
 import { getPrisma } from '@/lib/prisma'
 import { ExpenseFormValues, GroupFormValues } from '@/lib/schemas'
 import { Expense } from '@prisma/client'
+import { nanoid } from 'nanoid'
 
 export function randomId() {
-  return Math.random().toString(36).slice(2, 9)
+  return nanoid()
 }
 
 export async function createGroup(groupFormValues: GroupFormValues) {


### PR DESCRIPTION
This PR replaces Math.random-based id generator with [nanoid](https://github.com/ai/nanoid) which looks like this:

```
ZA4xhzA2RB5pU_2mdZDp9
```

It has multiple security benefits:

  * Longer ids which make brute force attacks basically impossible
  * Safe randomness
  * Collision resistance

I also added .env.example to save some time for future contributors