### PR TITLE
Fix create expense form when clicking reimbursement link in balances page

### DIFF
--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -80,6 +80,7 @@ export function ExpenseForm({ group, expense, onSubmit, onDelete }: Props) {
               : undefined,
           ],
           isReimbursement: true,
+          splitMode: 'EVENLY',
         }
       : {
           title: '',


### PR DESCRIPTION
Upon clicking "Mark as Paid" in the group balances tab, this redirects to the create expense page with argument "reimbursement".
The value for splitMode is not set in this instance so the UI renders the "shares" controls

To fix, explicitly set splitMode: 'EVENLY' for the reimbursement scenario.
