### PR TITLE
Add support for multiple payers

### DIFF
--- a/prisma/migrations/20240422155730_add_multiple_payers/migration.sql
+++ b/prisma/migrations/20240422155730_add_multiple_payers/migration.sql
@@ -1,0 +1,62 @@
+/*
+  Note: This migration file was manually updated to preserve the data in the `paidById` column of the older
+  `Expense` table. The original (automatically generated) migration file contents are available below.
+*/
+
+/* Step 1: setup new `ExpensePaidBy` table */
+-- CreateTable
+CREATE TABLE "ExpensePaidBy" (
+    "expenseId" TEXT NOT NULL,
+    "participantId" TEXT NOT NULL,
+    "amount" INTEGER NOT NULL,
+
+    CONSTRAINT "ExpensePaidBy_pkey" PRIMARY KEY ("expenseId","participantId")
+);
+
+-- AddForeignKey
+ALTER TABLE "ExpensePaidBy" ADD CONSTRAINT "ExpensePaidBy_expenseId_fkey" FOREIGN KEY ("expenseId") REFERENCES "Expense"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ExpensePaidBy" ADD CONSTRAINT "ExpensePaidBy_participantId_fkey" FOREIGN KEY ("participantId") REFERENCES "Participant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+/* Step 2: insert old `paidById` data into new `ExpensePaidBy` table */
+INSERT INTO "ExpensePaidBy"
+	SELECT "id" AS "expenseId", "paidById" AS "participantId", amount
+	FROM "Expense";
+
+/* Step 3: remove old `paidById` column */
+-- DropForeignKey
+ALTER TABLE "Expense" DROP CONSTRAINT "Expense_paidById_fkey";
+
+-- AlterTable
+ALTER TABLE "Expense" DROP COLUMN "paidById";
+
+/* Original migration file contents: */
+/*
+  Warnings:
+
+  - You are about to drop the column `paidById` on the `Expense` table. All the data in the column will be lost.
+
+*/
+/*
+-- DropForeignKey
+ALTER TABLE "Expense" DROP CONSTRAINT "Expense_paidById_fkey";
+
+-- AlterTable
+ALTER TABLE "Expense" DROP COLUMN "paidById";
+
+-- CreateTable
+CREATE TABLE "ExpensePaidBy" (
+    "expenseId" TEXT NOT NULL,
+    "participantId" TEXT NOT NULL,
+    "amount" INTEGER NOT NULL,
+
+    CONSTRAINT "ExpensePaidBy_pkey" PRIMARY KEY ("expenseId","participantId")
+);
+
+-- AddForeignKey
+ALTER TABLE "ExpensePaidBy" ADD CONSTRAINT "ExpensePaidBy_expenseId_fkey" FOREIGN KEY ("expenseId") REFERENCES "Expense"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ExpensePaidBy" ADD CONSTRAINT "ExpensePaidBy_participantId_fkey" FOREIGN KEY ("participantId") REFERENCES "Participant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+*/

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,7 +26,7 @@ model Participant {
   name            String
   group           Group            @relation(fields: [groupId], references: [id], onDelete: Cascade)
   groupId         String
-  expensesPaidBy  Expense[]
+  expensesPaidBy  ExpensePaidBy[]
   expensesPaidFor ExpensePaidFor[]
 }
 
@@ -45,8 +45,7 @@ model Expense {
   category        Category?         @relation(fields: [categoryId], references: [id])
   categoryId      Int               @default(0)
   amount          Int
-  paidBy          Participant       @relation(fields: [paidById], references: [id], onDelete: Cascade)
-  paidById        String
+  paidBy          ExpensePaidBy[]
   paidFor         ExpensePaidFor[]
   groupId         String
   isReimbursement Boolean           @default(false)
@@ -78,6 +77,16 @@ model ExpensePaidFor {
   expenseId     String
   participantId String
   shares        Int         @default(1)
+
+  @@id([expenseId, participantId])
+}
+
+model ExpensePaidBy {
+  expense       Expense     @relation(fields: [expenseId], references: [id], onDelete: Cascade)
+  participant   Participant @relation(fields: [participantId], references: [id], onDelete: Cascade)
+  expenseId     String
+  participantId String
+  amount        Int
 
   @@id([expenseId, participantId])
 }

--- a/src/app/groups/[groupId]/expenses/active-user-balance.tsx
+++ b/src/app/groups/[groupId]/expenses/active-user-balance.tsx
@@ -20,7 +20,7 @@ export function ActiveUserBalance({ groupId, currency, expense }: Props) {
   if (Object.hasOwn(balances, activeUserId)) {
     const balance = balances[activeUserId]
     let balanceDetail = <></>
-    if (balance.paid > 0 && balance.paidFor > 0) {
+    if (balance.paid != 0 && balance.paidFor != 0) {
       balanceDetail = (
         <>
           {' ('}

--- a/src/app/groups/[groupId]/expenses/expense-card.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-card.tsx
@@ -16,6 +16,16 @@ type Props = {
 }
 
 export function ExpenseCard({ expense, currency, groupId }: Props) {
+  const getParticipantList = (ps: { participant: { name: string } }[]) => (
+    <>
+      {ps.map(({ participant }, index) => (
+        <Fragment key={index}>
+          {index !== 0 && <>, </>}
+          <strong>{participant.name}</strong>
+        </Fragment>
+      ))}
+    </>
+  )
   const router = useRouter()
 
   return (
@@ -39,13 +49,8 @@ export function ExpenseCard({ expense, currency, groupId }: Props) {
         </div>
         <div className="text-xs text-muted-foreground">
           {expense.amount > 0 ? 'Paid by ' : 'Received by '}
-          <strong>{expense.paidBy.name}</strong> for{' '}
-          {expense.paidFor.map((paidFor, index) => (
-            <Fragment key={index}>
-              {index !== 0 && <>, </>}
-              <strong>{paidFor.participant.name}</strong>
-            </Fragment>
-          ))}
+          {getParticipantList(expense.paidBy)} for{' '}
+          {getParticipantList(expense.paidFor)}
         </div>
         <div className="text-xs text-muted-foreground">
           <ActiveUserBalance {...{ groupId, currency, expense }} />

--- a/src/app/groups/[groupId]/expenses/export/json/route.ts
+++ b/src/app/groups/[groupId]/expenses/export/json/route.ts
@@ -18,7 +18,7 @@ export async function GET(
           title: true,
           category: { select: { grouping: true, name: true } },
           amount: true,
-          paidById: true,
+          paidBy: { select: { participantId: true, amount: true } },
           paidFor: { select: { participantId: true, shares: true } },
           isReimbursement: true,
           splitMode: true,

--- a/src/components/amount-input.tsx
+++ b/src/components/amount-input.tsx
@@ -1,0 +1,69 @@
+'use client'
+import * as React from 'react'
+
+import { Input, InputProps } from '@/components/ui/input'
+import { cn } from '@/lib/utils'
+
+type Props = InputProps & {
+  step?: number
+  onChange: (amount: string) => void
+  prefix?: string
+  postfix?: string
+  affixClassName?: string
+}
+
+const enforceAmountPattern = (value: string) =>
+  value
+    .replace(/[#_]/g, '') // remove all # and _ characters
+    .replace(/^\s*-/, '_') // replace leading minus with _
+    .replace(/[.,]/, '#') // replace first comma with #
+    .replace(/[-.,]/g, '') // remove other minus and commas characters
+    .replace(/_/, '-') // change back _ to minus
+    .replace(/#/, '.') // change back # to dot
+    .replace(/[^-\d.]/g, '') // remove all non-numeric characters
+
+const AmountInput = React.forwardRef<HTMLInputElement, Props>(
+  (
+    {
+      className,
+      affixClassName,
+      step = 0.01,
+      prefix,
+      postfix,
+      onChange,
+      ...props
+    },
+    ref,
+  ) => {
+    return (
+      <div className="flex items-baseline gap-2">
+        {prefix !== undefined && (
+          <span className={cn(affixClassName)}>{prefix}</span>
+        )}
+        <Input
+          className={cn('text-base', className)}
+          type="text"
+          inputMode={step >= 1 ? 'numeric' : 'decimal'}
+          step={step}
+          placeholder={step >= 1 ? '0' : String(step).replace(/\d/g, '0')}
+          onChange={(event) =>
+            onChange(enforceAmountPattern(event.target.value))
+          }
+          onFocus={(e) => {
+            // we're adding a small delay to get around safaris issue with onMouseUp deselecting things again
+            const target = e.currentTarget
+            setTimeout(() => target.select(), 1)
+          }}
+          ref={ref}
+          {...props}
+        />
+        {postfix !== undefined && (
+          <span className={cn(affixClassName)}>{postfix}</span>
+        )}
+      </div>
+    )
+  },
+)
+AmountInput.displayName = 'AmountInput'
+
+export { AmountInput }

--- a/src/components/money.tsx
+++ b/src/components/money.tsx
@@ -17,7 +17,7 @@ export function Money({
   return (
     <span
       className={cn(
-        colored && amount <= 1
+        colored && amount <= -1
           ? 'text-red-600'
           : colored && amount >= 1
           ? 'text-green-600'

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -145,7 +145,8 @@ const FormMessage = React.forwardRef<
   React.HTMLAttributes<HTMLParagraphElement>
 >(({ className, children, ...props }, ref) => {
   const { error, formMessageId } = useFormField()
-  const body = error ? String(error?.message) : children
+  const hasError = (error?.message || error?.root?.message) // False for nested errors of field arrays
+  const body = (hasError) ? String(error.message ?? error.root?.message) : children
 
   if (!body) {
     return null

--- a/src/lib/balances.ts
+++ b/src/lib/balances.ts
@@ -19,11 +19,14 @@ export function getBalances(
   const balances: Balances = {}
 
   for (const expense of expenses) {
-    const paidBy = expense.paidBy.id
+    const paidBys = expense.paidBy
     const paidFors = expense.paidFor
 
-    if (!balances[paidBy]) balances[paidBy] = { paid: 0, paidFor: 0, total: 0 }
-    balances[paidBy].paid += expense.amount
+    paidBys.forEach((paidBy) => {
+      if (!balances[paidBy.participant.id])
+        balances[paidBy.participant.id] = { paid: 0, paidFor: 0, total: 0 }
+      balances[paidBy.participant.id].paid += paidBy.amount
+    })
 
     const totalPaidForShares = paidFors.reduce(
       (sum, paidFor) => sum + paidFor.shares,

--- a/src/lib/totals.ts
+++ b/src/lib/totals.ts
@@ -14,13 +14,14 @@ export function getTotalActiveUserPaidFor(
   activeUserId: string | null,
   expenses: NonNullable<Awaited<ReturnType<typeof getGroupExpenses>>>,
 ): number {
-  return expenses.reduce(
-    (total, expense) =>
-      expense.paidBy.id === activeUserId && !expense.isReimbursement
-        ? total + expense.amount
-        : total,
-    0,
-  )
+  return expenses.reduce((total, expense) => {
+    const userPaidBy = expense.paidBy.find(
+      (paidBy) => paidBy.participant.id === activeUserId,
+    )
+    return userPaidBy && !expense.isReimbursement
+      ? total + userPaidBy.amount
+      : total
+  }, 0)
 }
 
 export function getTotalActiveUserShare(


### PR DESCRIPTION
This PR adds support for multiple payers of a certain expense. The database changes are minimal and resemble the structure of the `paidFor` expense field. There's quite some changes to the interface, mostly to the expense form, which are showcased in the video below.

https://github.com/spliit-app/spliit/assets/15089458/36a27f6d-e02a-41c7-a89e-3d60b1585722

The PR is in a finished state, however it is still marked as draft as I don't know how to provide a correct migration strategy for existing databases (the prisma generated one just seems to drop the `paidById` column entirely). Some help there would be appreciated. The necessary migration is not too complicated: for each existing expense a new `ExpensePaidBy` row must be created with `participantId` equal to the old `paidById`, `expenseId` equal to the corresponding expense `id` and `amount` equal to the expense's (total) `amount`.

Closes #14.

Additionally fixes some small bugs regarding amount and balance formatting (this might resolve issues #87 and #140). Also resolves #156 by increasing the upper bound to 10 billion.