### PR TITLE
Increased currency field max length

### DIFF
--- a/src/components/group-form.tsx
+++ b/src/components/group-form.tsx
@@ -153,7 +153,7 @@ export function GroupForm({
                     <Input
                       className="text-base"
                       placeholder={t('CurrencyField.placeholder')}
-                      max={5}
+                      max={15}
                       {...field}
                     />
                   </FormControl>


### PR DESCRIPTION
Hi ! Just made a really small change to allow bigger currency symbols.

This allows using fun words instead of real currencies, not any other reason behind this proposal haha

This is a really nice application ! Thanks for making it :D 

(15 chars is also arbitrary, didnt know if completely removing this limit could also do the trick)