### PR TITLE
Set split mode to EVENLY for reimbursements in ExpenseForm

### DIFF
--- a/src/app/groups/[groupId]/expenses/expense-form.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-form.tsx
@@ -230,7 +230,9 @@ export function ExpenseForm({
               : undefined,
           ],
           isReimbursement: true,
-          splitMode: defaultSplittingOptions.splitMode,
+          // Mark as paid reimbursements should always be split evenly
+          // independent of any stored default splitting options.
+          splitMode: 'EVENLY',
           saveDefaultSplittingOptions: false,
           documents: [],
           notes: '',


### PR DESCRIPTION
See Issue #365 

Updates expense-form.tsx so that Mark As Paid reimbursements always use the EVENLY split mode rather than the group’s saved defaults. 