### PR TITLE
Add default currency on group creation using locale and localStorage (includes translation fallback)

### DIFF
--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -14,6 +14,9 @@
     "madeIn": "Entwickelt in Montréal, Québec 🇨🇦",
     "builtBy": "Erstellt von <author>Sebastien Castiel</author> und <source>Mitwirkenden</source>"
   },
+  "Currency": {
+    "default": "€"
+  },
   "Expenses": {
     "title": "Ausgaben",
     "description": "Hier sind die Ausgaben, die du für deine Gruppe erstellt hast.",

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -14,6 +14,9 @@
     "madeIn": "Made in Montréal, Québec 🇨🇦",
     "builtBy": "Built by <author>Sebastien Castiel</author> and <source>contributors</source>"
   },
+  "Currency": {
+    "default": "$"
+  },
   "Expenses": {
     "title": "Expenses",
     "description": "Here are the expenses that you created for your group.",

--- a/src/app/groups/create/create-group.tsx
+++ b/src/app/groups/create/create-group.tsx
@@ -13,6 +13,12 @@ export const CreateGroup = () => {
     <GroupForm
       onSubmit={async (groupFormValues) => {
         const { groupId } = await mutateAsync({ groupFormValues })
+
+        // Store the actual currency as default in localStorage
+        if (typeof localStorage !== 'undefined') {
+          localStorage.setItem('defaultCurrency', groupFormValues.currency)
+        }
+
         await utils.groups.invalidate()
         router.push(`/groups/${groupId}`)
       }}

--- a/src/components/group-form.tsx
+++ b/src/components/group-form.tsx
@@ -55,19 +55,29 @@ export function GroupForm({
   protectedParticipantIds = [],
 }: Props) {
   const t = useTranslations('GroupForm')
+
+  // Use default currency from group or localStorage
+  const tCurrency = useTranslations('Currency')
+  const defaultCurrency = group
+    ? group.currency
+    : (typeof localStorage !== 'undefined' &&
+        localStorage.getItem('defaultCurrency')) ||
+      tCurrency('default')
+
+
   const form = useForm<GroupFormValues>({
     resolver: zodResolver(groupFormSchema),
     defaultValues: group
       ? {
           name: group.name,
           information: group.information ?? '',
-          currency: group.currency,
+          currency: defaultCurrency,
           participants: group.participants,
         }
       : {
           name: '',
           information: '',
-          currency: process.env.NEXT_PUBLIC_DEFAULT_CURRENCY_SYMBOL || '',
+          currency: defaultCurrency,
           participants: [
             { name: t('Participants.John') },
             { name: t('Participants.Jane') },

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,6 +1,7 @@
 import { getRequestConfig } from 'next-intl/server'
 import { getUserLocale } from './lib/locale'
 
+// helper to merge locale-specific messages with the English defaults
 function mergeDeep<T>(target: T, source: Partial<T>): T {
   for (const key in source) {
     const value = (source as any)[key]


### PR DESCRIPTION
See #370 

Group form now pre-fills the currency field based on:
- the last selected value stored in localStorage, or
- a locale-specific default defined in the translation messages

Implemented fallback logic for missing translation keys (from previous PR #369)
→ Avoids the need to define the default currency in every language file

Fallback default: "$" for English (en)
- Locale default for German (de) set to "€" (as a test case)

This improves UX during onboarding and testing, especially by preventing empty or forgotten currency fields.