### PR TITLE
fix(expenses): Correct data inconsistency for "Split Evenly" mode in context of default splitting

### DIFF
--- a/prisma/migrations/20250701155133_cleanup_evenly_shares/migration.sql
+++ b/prisma/migrations/20250701155133_cleanup_evenly_shares/migration.sql
@@ -1,0 +1,11 @@
+-- This migration cleans up existing data where the split mode is 'EVENLY'
+-- but the shares are not set to 1. This ensures data consistency for
+-- all expenses that should be split equally.
+
+UPDATE "ExpensePaidFor"
+SET "shares" = 1
+WHERE "expenseId" IN (
+  SELECT "id"
+  FROM "Expense"
+  WHERE "splitMode" = 'EVENLY'
+);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -64,6 +64,14 @@ export async function createExpense(
     groupId,
   )
 
+  const paidFor =
+    expenseFormValues.splitMode === 'EVENLY'
+      ? expenseFormValues.paidFor.map(({ participant }) => ({
+          participant,
+          shares: 1,
+        }))
+      : expenseFormValues.paidFor
+
   return prisma.expense.create({
     data: {
       id: expenseId,
@@ -87,7 +95,7 @@ export async function createExpense(
       },
       paidFor: {
         createMany: {
-          data: expenseFormValues.paidFor.map((paidFor) => ({
+          data: paidFor.map((paidFor) => ({
             participantId: paidFor.participant,
             shares: paidFor.shares,
           })),
@@ -204,6 +212,14 @@ export async function updateExpense(
     existingExpense.expenseDate,
   )
 
+  const paidFor =
+    expenseFormValues.splitMode === 'EVENLY'
+      ? expenseFormValues.paidFor.map(({ participant }) => ({
+          participant,
+          shares: 1,
+        }))
+      : expenseFormValues.paidFor
+
   return prisma.expense.update({
     where: { id: expenseId },
     data: {
@@ -218,7 +234,7 @@ export async function updateExpense(
       splitMode: expenseFormValues.splitMode,
       recurrenceRule: expenseFormValues.recurrenceRule,
       paidFor: {
-        create: expenseFormValues.paidFor
+        create: paidFor
           .filter(
             (p) =>
               !existingExpense.paidFor.some(
@@ -229,7 +245,7 @@ export async function updateExpense(
             participantId: paidFor.participant,
             shares: paidFor.shares,
           })),
-        update: expenseFormValues.paidFor.map((paidFor) => ({
+        update: paidFor.map((paidFor) => ({
           where: {
             expenseId_participantId: {
               expenseId,


### PR DESCRIPTION
**Summary**
  This pull request addresses a critical data inconsistency bug that occurs when an expense is set to be split evenly, but a default (uneven) splitting configuration also exists. The bug caused incorrect amounts
  to be calculated in features like the CSV export because the underlying shares for participants were not being correctly normalized.

  This PR introduces a fix in the core API logic to ensure data is stored correctly and adds a database migration to clean up any existing inconsistent data.

  **Problem Description**
  When a user creates or updates an expense and selects the "Split Evenly" option, the application should divide the cost equally among all selected participants. However, if a default splitting configuration
  with uneven shares was previously set for those participants, the application was incorrectly preserving these old, uneven shares in the database while setting the splitMode to EVENLY.

  This resulted in a contradictory state where an expense was marked as "evenly split" but had data indicating an uneven distribution. This incorrect data was then used in the CSV export, leading to confusing and
  inaccurate reports for users.

  **Solution Implemented**
  The solution is two-fold to ensure correctness for both new and existing data:

   1. API Logic Correction: The createExpense and updateExpense functions have been updated to enforce data consistency. Before creating or updating an expense, the code now checks if the splitMode is EVENLY. If it
      is, it programmatically overrides any incoming shares and sets them to 1 for all participants involved. This ensures that the data saved to the database is always correct from this point forward.

   2. Data Migration for Existing Entries: A new Prisma migration has been added to clean up existing records in the database. The migration runs a single SQL UPDATE statement that finds all expenses with splitMode
      = 'EVENLY' and normalizes the shares in the corresponding ExpensePaidFor table to 1. This is a one-time fix that ensures historical data is also corrected.
