### PR TITLE
feat(expense): support multiple payers (port #146)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,47 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `src/app`: Next.js App Router routes and pages.
+- `src/components` (`ui/`): Reusable React components.
+- `src/lib`: Utilities, schemas, env/prisma setup.
+- `src/trpc` (`routers/`): tRPC server/client code.
+- `prisma`: Prisma schema and migrations.
+- `messages`: i18n locale JSON files.
+- `public`: Static assets (icons, images, manifest).
+- `scripts`: Dev helpers (DB, container, build).
+
+## Build, Test, and Development Commands
+- `npm run dev`: Start dev server at `http://localhost:3000`.
+- `npm run build`: Production build (Next.js).
+- `npm start`: Start production server.
+- `npm run lint`: Run ESLint (Next core-web-vitals).
+- `npm run check-types`: Type-check with TypeScript.
+- `npm run prettier` / `npm run check-formatting`: Format or verify with Prettier.
+- `npm test`: Run Jest tests (jsdom).
+- `./scripts/start-local-db.sh`: Launch local Postgres via Docker.
+- `npm run build-image` / `npm run start-container`: Build image and run with Compose.
+
+## Coding Style & Naming Conventions
+- Language: TypeScript + React; Tailwind for styles.
+- Prettier: no semicolons, single quotes, organized imports.
+- ESLint: `next/core-web-vitals`. Indentation: 2 spaces.
+- Components: PascalCase (`src/components/Button.tsx`).
+- Utilities: camelCase in `src/lib` (`formatCurrency.ts`).
+- Routes: `src/app/<route>/page.tsx`; colocate server/client helpers nearby when sensible.
+- tRPC: one router per domain in `src/trpc/routers`.
+
+## Testing Guidelines
+- Frameworks: Jest + Testing Library; environment `jsdom`.
+- Location: colocate as `*.test.ts(x)` (e.g., `src/lib/utils.test.ts`).
+- Scope: favor small, deterministic tests; mock network/DB.
+- Run: `npm test` (add focused tests with `it.only` during development; remove before commit).
+
+## Commit & Pull Request Guidelines
+- Commits: imperative mood, concise subject; reference issues `#123` when relevant.
+- Schema changes: include Prisma migration files and regenerate client.
+  - Example: `npx prisma migrate dev -n add-recurring-expense`.
+- PRs: clear description, linked issues, screenshots for UI, steps to verify, and notes on migrations/env changes.
+
+## Security & Configuration Tips
+- Never commit secrets. Copy `.env.example` → `.env` (or `container.env.example` → `container.env`).
+- Feature flags: enable optional features via env (e.g., `NEXT_PUBLIC_ENABLE_EXPENSE_DOCUMENTS`).

--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -140,7 +140,6 @@
       "recurrenceRule": {
         "label": "Expense Recurrence",
         "description": "Select how often the expense should repeat.",
-
         "none": "None",
         "daily": "Daily",
         "weekly": "Weekly",
@@ -214,7 +213,9 @@
     "save": "Speichern",
     "saving": "Speichert…",
     "cancel": "Abbrechen",
-    "reimbursement": "Rückzahlung"
+    "reimbursement": "Rückzahlung",
+    "participant": "Participant",
+    "total": "Total"
   },
   "ExpenseDocumentsInput": {
     "TooBigToast": {

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -194,6 +194,8 @@
     "selectAll": "Select all",
     "shares": "share(s)",
     "advancedOptions": "Advanced splitting options…",
+    "participant": "Participant",
+    "total": "Total",
     "SplitModeField": {
       "label": "Split mode",
       "evenly": "Evenly",

--- a/messages/es.json
+++ b/messages/es.json
@@ -140,7 +140,6 @@
       "recurrenceRule": {
         "label": "Recurrencia del gasto",
         "description": "Seleccione con qué frecuencia debe repetirse el gasto.",
-
         "none": "Ninguno",
         "daily": "Diario",
         "weekly": "Semanal",
@@ -214,7 +213,9 @@
     "save": "Guardar",
     "saving": "Guardando",
     "cancel": "Cancelar",
-    "reimbursement": "Reembolso"
+    "reimbursement": "Reembolso",
+    "participant": "Participant",
+    "total": "Total"
   },
   "ExpenseDocumentsInput": {
     "TooBigToast": {

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -140,7 +140,6 @@
       "recurrenceRule": {
         "label": "Expense Recurrence",
         "description": "Select how often the expense should repeat.",
-
         "none": "None",
         "daily": "Daily",
         "weekly": "Weekly",
@@ -214,7 +213,9 @@
     "save": "Tallenna",
     "saving": "Tallennetaan…",
     "cancel": "Peruuta",
-    "reimbursement": "Velanmaksu"
+    "reimbursement": "Velanmaksu",
+    "participant": "Participant",
+    "total": "Total"
   },
   "ExpenseDocumentsInput": {
     "TooBigToast": {

--- a/messages/fr-FR.json
+++ b/messages/fr-FR.json
@@ -140,7 +140,6 @@
       "recurrenceRule": {
         "label": "Expense Recurrence",
         "description": "Select how often the expense should repeat.",
-
         "none": "None",
         "daily": "Daily",
         "weekly": "Weekly",
@@ -214,7 +213,9 @@
     "save": "Sauvegarder",
     "saving": "Sauvegarde…",
     "cancel": "Annuler",
-    "reimbursement": "Remboursement"
+    "reimbursement": "Remboursement",
+    "participant": "Participant",
+    "total": "Total"
   },
   "ExpenseDocumentsInput": {
     "TooBigToast": {

--- a/messages/it-IT.json
+++ b/messages/it-IT.json
@@ -140,7 +140,6 @@
       "recurrenceRule": {
         "label": "Expense Recurrence",
         "description": "Select how often the expense should repeat.",
-
         "none": "None",
         "daily": "Daily",
         "weekly": "Weekly",
@@ -214,7 +213,9 @@
     "save": "Salva",
     "saving": "Sto salvando…",
     "cancel": "Annulla",
-    "reimbursement": "Rimborso"
+    "reimbursement": "Rimborso",
+    "participant": "Participant",
+    "total": "Total"
   },
   "ExpenseDocumentsInput": {
     "TooBigToast": {

--- a/messages/nl-NL.json
+++ b/messages/nl-NL.json
@@ -205,7 +205,9 @@
     "save": "Sla op",
     "saving": "Opslaan…",
     "cancel": "Annuleer",
-    "reimbursement": "Terugbetaling"
+    "reimbursement": "Terugbetaling",
+    "participant": "Participant",
+    "total": "Total"
   },
   "ExpenseDocumentsInput": {
     "TooBigToast": {

--- a/messages/pl-PL.json
+++ b/messages/pl-PL.json
@@ -140,7 +140,6 @@
       "recurrenceRule": {
         "label": "Expense Recurrence",
         "description": "Select how often the expense should repeat.",
-
         "none": "None",
         "daily": "Daily",
         "weekly": "Weekly",
@@ -214,7 +213,9 @@
     "save": "Zapisz",
     "saving": "Zapisywanie…",
     "cancel": "Anuluj",
-    "reimbursement": "Zwrot środków"
+    "reimbursement": "Zwrot środków",
+    "participant": "Participant",
+    "total": "Total"
   },
   "ExpenseDocumentsInput": {
     "TooBigToast": {

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -205,7 +205,9 @@
     "save": "Salvar",
     "saving": "Salvando…",
     "cancel": "Cancelar",
-    "reimbursement": "Reembolso"
+    "reimbursement": "Reembolso",
+    "participant": "Participant",
+    "total": "Total"
   },
   "ExpenseDocumentsInput": {
     "TooBigToast": {

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -131,7 +131,6 @@
       "recurrenceRule": {
         "label": "Expense Recurrence",
         "description": "Select how often the expense should repeat.",
-
         "none": "None",
         "daily": "Daily",
         "weekly": "Weekly",
@@ -214,7 +213,9 @@
     "save": "Salvează",
     "saving": "Se salvează…",
     "cancel": "Anulează",
-    "reimbursement": "Rambursare"
+    "reimbursement": "Rambursare",
+    "participant": "Participant",
+    "total": "Total"
   },
   "ExpenseDocumentsInput": {
     "TooBigToast": {

--- a/messages/ru-RU.json
+++ b/messages/ru-RU.json
@@ -140,7 +140,6 @@
       "recurrenceRule": {
         "label": "Expense Recurrence",
         "description": "Select how often the expense should repeat.",
-
         "none": "None",
         "daily": "Daily",
         "weekly": "Weekly",
@@ -214,7 +213,9 @@
     "save": "Сохранить",
     "saving": "Сохранение…",
     "cancel": "Отмена",
-    "reimbursement": "Возмещение"
+    "reimbursement": "Возмещение",
+    "participant": "Participant",
+    "total": "Total"
   },
   "ExpenseDocumentsInput": {
     "TooBigToast": {

--- a/messages/tr-TR.json
+++ b/messages/tr-TR.json
@@ -205,7 +205,9 @@
     "save": "Kaydet",
     "saving": "Kaydediliyor…",
     "cancel": "İptal",
-    "reimbursement": "Geri ödeme"
+    "reimbursement": "Geri ödeme",
+    "participant": "Participant",
+    "total": "Total"
   },
   "ExpenseDocumentsInput": {
     "TooBigToast": {

--- a/messages/ua-UA.json
+++ b/messages/ua-UA.json
@@ -140,7 +140,6 @@
       "recurrenceRule": {
         "label": "Expense Recurrence",
         "description": "Select how often the expense should repeat.",
-
         "none": "None",
         "daily": "Daily",
         "weekly": "Weekly",
@@ -214,7 +213,9 @@
     "save": "Зберегти",
     "saving": "Збереження..",
     "cancel": "Скасувати",
-    "reimbursement": "Відшкодування"
+    "reimbursement": "Відшкодування",
+    "participant": "Participant",
+    "total": "Total"
   },
   "ExpenseDocumentsInput": {
     "TooBigToast": {

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -140,7 +140,6 @@
       "recurrenceRule": {
         "label": "Expense Recurrence",
         "description": "Select how often the expense should repeat.",
-
         "none": "None",
         "daily": "Daily",
         "weekly": "Weekly",
@@ -214,7 +213,9 @@
     "save": "保存",
     "saving": "保存中……",
     "cancel": "取消",
-    "reimbursement": "报销"
+    "reimbursement": "报销",
+    "participant": "Participant",
+    "total": "Total"
   },
   "ExpenseDocumentsInput": {
     "TooBigToast": {

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -205,7 +205,9 @@
     "save": "儲存",
     "saving": "儲存中……",
     "cancel": "取消",
-    "reimbursement": "報銷"
+    "reimbursement": "報銷",
+    "participant": "Participant",
+    "total": "Total"
   },
   "ExpenseDocumentsInput": {
     "TooBigToast": {

--- a/prisma/migrations/20240422155730_add_multiple_payers/migration.sql
+++ b/prisma/migrations/20240422155730_add_multiple_payers/migration.sql
@@ -1,0 +1,62 @@
+/*
+  Note: This migration file was manually updated to preserve the data in the `paidById` column of the older
+  `Expense` table. The original (automatically generated) migration file contents are available below.
+*/
+
+/* Step 1: setup new `ExpensePaidBy` table */
+-- CreateTable
+CREATE TABLE "ExpensePaidBy" (
+    "expenseId" TEXT NOT NULL,
+    "participantId" TEXT NOT NULL,
+    "amount" INTEGER NOT NULL,
+
+    CONSTRAINT "ExpensePaidBy_pkey" PRIMARY KEY ("expenseId","participantId")
+);
+
+-- AddForeignKey
+ALTER TABLE "ExpensePaidBy" ADD CONSTRAINT "ExpensePaidBy_expenseId_fkey" FOREIGN KEY ("expenseId") REFERENCES "Expense"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ExpensePaidBy" ADD CONSTRAINT "ExpensePaidBy_participantId_fkey" FOREIGN KEY ("participantId") REFERENCES "Participant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+/* Step 2: insert old `paidById` data into new `ExpensePaidBy` table */
+INSERT INTO "ExpensePaidBy"
+	SELECT "id" AS "expenseId", "paidById" AS "participantId", amount
+	FROM "Expense";
+
+/* Step 3: remove old `paidById` column */
+-- DropForeignKey
+ALTER TABLE "Expense" DROP CONSTRAINT "Expense_paidById_fkey";
+
+-- AlterTable
+ALTER TABLE "Expense" DROP COLUMN "paidById";
+
+/* Original migration file contents: */
+/*
+  Warnings:
+
+  - You are about to drop the column `paidById` on the `Expense` table. All the data in the column will be lost.
+
+*/
+/*
+-- DropForeignKey
+ALTER TABLE "Expense" DROP CONSTRAINT "Expense_paidById_fkey";
+
+-- AlterTable
+ALTER TABLE "Expense" DROP COLUMN "paidById";
+
+-- CreateTable
+CREATE TABLE "ExpensePaidBy" (
+    "expenseId" TEXT NOT NULL,
+    "participantId" TEXT NOT NULL,
+    "amount" INTEGER NOT NULL,
+
+    CONSTRAINT "ExpensePaidBy_pkey" PRIMARY KEY ("expenseId","participantId")
+);
+
+-- AddForeignKey
+ALTER TABLE "ExpensePaidBy" ADD CONSTRAINT "ExpensePaidBy_expenseId_fkey" FOREIGN KEY ("expenseId") REFERENCES "Expense"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ExpensePaidBy" ADD CONSTRAINT "ExpensePaidBy_participantId_fkey" FOREIGN KEY ("participantId") REFERENCES "Participant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+*/

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,7 +27,7 @@ model Participant {
   name            String
   group           Group            @relation(fields: [groupId], references: [id], onDelete: Cascade)
   groupId         String
-  expensesPaidBy  Expense[]
+  expensesPaidBy  ExpensePaidBy[]
   expensesPaidFor ExpensePaidFor[]
 }
 
@@ -46,8 +46,7 @@ model Expense {
   category        Category?         @relation(fields: [categoryId], references: [id])
   categoryId      Int               @default(0)
   amount          Int
-  paidBy          Participant       @relation(fields: [paidById], references: [id], onDelete: Cascade)
-  paidById        String
+  paidBy          ExpensePaidBy[]
   paidFor         ExpensePaidFor[]
   groupId         String
   isReimbursement Boolean           @default(false)
@@ -106,6 +105,16 @@ model ExpensePaidFor {
   expenseId     String
   participantId String
   shares        Int         @default(1)
+
+  @@id([expenseId, participantId])
+}
+
+model ExpensePaidBy {
+  expense       Expense     @relation(fields: [expenseId], references: [id], onDelete: Cascade)
+  participant   Participant @relation(fields: [participantId], references: [id], onDelete: Cascade)
+  expenseId     String
+  participantId String
+  amount        Int
 
   @@id([expenseId, participantId])
 }

--- a/src/app/groups/[groupId]/expenses/active-user-balance.tsx
+++ b/src/app/groups/[groupId]/expenses/active-user-balance.tsx
@@ -22,7 +22,7 @@ export function ActiveUserBalance({ groupId, currency, expense }: Props) {
   if (Object.hasOwn(balances, activeUserId)) {
     const balance = balances[activeUserId]
     let balanceDetail = <></>
-    if (balance.paid > 0 && balance.paidFor > 0) {
+    if (balance.paid != 0 && balance.paidFor != 0) {
       balanceDetail = (
         <>
           {' ('}

--- a/src/app/groups/[groupId]/expenses/expense-card.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-card.tsx
@@ -24,7 +24,12 @@ function Participants({ expense }: { expense: Expense }) {
   ))
   const participants = t.rich(key, {
     strong: (chunks) => <strong>{chunks}</strong>,
-    paidBy: expense.paidBy.name,
+    paidBy: Array.isArray(expense.paidBy)
+      ? expense.paidBy
+          .map((pb) => pb.participant.name)
+          .join(', ')
+      : // fallback for older shape
+        (expense as any).paidBy?.name,
     paidFor: () => paidFor,
     forCount: expense.paidFor.length,
   })

--- a/src/app/groups/[groupId]/expenses/export/csv/route.ts
+++ b/src/app/groups/[groupId]/expenses/export/csv/route.ts
@@ -36,7 +36,7 @@ export async function GET(
           title: true,
           category: { select: { name: true } },
           amount: true,
-          paidById: true,
+          paidBy: { select: { participantId: true, amount: true } },
           paidFor: { select: { participantId: true, shares: true } },
           isReimbursement: true,
           splitMode: true,
@@ -112,7 +112,9 @@ export async function GET(
           { totalShares: 0, participantShare: 0 },
         )
 
-        const isPaidByParticipant = expense.paidById === participant.id
+        const isPaidByParticipant = expense.paidBy.some(
+          (pb) => pb.participantId === participant.id,
+        )
         const participantAmountShare = +(
           ((expense.amount / totalShares) * participantShare) /
           100

--- a/src/app/groups/[groupId]/expenses/export/json/route.ts
+++ b/src/app/groups/[groupId]/expenses/export/json/route.ts
@@ -19,7 +19,7 @@ export async function GET(
           title: true,
           category: { select: { grouping: true, name: true } },
           amount: true,
-          paidById: true,
+          paidBy: { select: { participantId: true, amount: true } },
           paidFor: { select: { participantId: true, shares: true } },
           isReimbursement: true,
           splitMode: true,

--- a/src/components/amount-input.tsx
+++ b/src/components/amount-input.tsx
@@ -1,0 +1,69 @@
+'use client'
+import * as React from 'react'
+
+import { Input, InputProps } from '@/components/ui/input'
+import { cn } from '@/lib/utils'
+
+type Props = InputProps & {
+  step?: number
+  onChange: (amount: string) => void
+  prefix?: string
+  postfix?: string
+  affixClassName?: string
+}
+
+const enforceAmountPattern = (value: string) =>
+  value
+    .replace(/[#_]/g, '') // remove all # and _ characters
+    .replace(/^\s*-/, '_') // replace leading minus with _
+    .replace(/[.,]/, '#') // replace first comma with #
+    .replace(/[-.,]/g, '') // remove other minus and commas characters
+    .replace(/_/, '-') // change back _ to minus
+    .replace(/#/, '.') // change back # to dot
+    .replace(/[^-\d.]/g, '') // remove all non-numeric characters
+
+const AmountInput = React.forwardRef<HTMLInputElement, Props>(
+  (
+    {
+      className,
+      affixClassName,
+      step = 0.01,
+      prefix,
+      postfix,
+      onChange,
+      ...props
+    },
+    ref,
+  ) => {
+    return (
+      <div className="flex items-baseline gap-2">
+        {prefix !== undefined && (
+          <span className={cn(affixClassName)}>{prefix}</span>
+        )}
+        <Input
+          className={cn('text-base', className)}
+          type="text"
+          inputMode={step >= 1 ? 'numeric' : 'decimal'}
+          step={step}
+          placeholder={step >= 1 ? '0' : String(step).replace(/\d/g, '0')}
+          onChange={(event) =>
+            onChange(enforceAmountPattern(event.target.value))
+          }
+          onFocus={(e) => {
+            // we're adding a small delay to get around safaris issue with onMouseUp deselecting things again
+            const target = e.currentTarget
+            setTimeout(() => target.select(), 1)
+          }}
+          ref={ref}
+          {...props}
+        />
+        {postfix !== undefined && (
+          <span className={cn(affixClassName)}>{postfix}</span>
+        )}
+      </div>
+    )
+  },
+)
+AmountInput.displayName = 'AmountInput'
+
+export { AmountInput }

--- a/src/lib/balances.ts
+++ b/src/lib/balances.ts
@@ -19,11 +19,25 @@ export function getBalances(
   const balances: Balances = {}
 
   for (const expense of expenses) {
-    const paidBy = expense.paidBy.id
     const paidFors = expense.paidFor
 
-    if (!balances[paidBy]) balances[paidBy] = { paid: 0, paidFor: 0, total: 0 }
-    balances[paidBy].paid += expense.amount
+    if (Array.isArray(expense.paidBy)) {
+      // Multiple payers: attribute paid amounts to each payer
+      for (const pb of expense.paidBy) {
+        const payerId = pb.participant.id
+        if (!balances[payerId])
+          balances[payerId] = { paid: 0, paidFor: 0, total: 0 }
+        balances[payerId].paid += pb.amount
+      }
+    } else {
+      // Fallback for legacy shape
+      const paidBy = (expense as any).paidBy?.id
+      if (paidBy) {
+        if (!balances[paidBy])
+          balances[paidBy] = { paid: 0, paidFor: 0, total: 0 }
+        balances[paidBy].paid += expense.amount
+      }
+    }
 
     const totalPaidForShares = paidFors.reduce(
       (sum, paidFor) => sum + paidFor.shares,

--- a/src/lib/totals.ts
+++ b/src/lib/totals.ts
@@ -14,13 +14,17 @@ export function getTotalActiveUserPaidFor(
   activeUserId: string | null,
   expenses: NonNullable<Awaited<ReturnType<typeof getGroupExpenses>>>,
 ): number {
-  return expenses.reduce(
-    (total, expense) =>
-      expense.paidBy.id === activeUserId && !expense.isReimbursement
-        ? total + expense.amount
-        : total,
-    0,
-  )
+  return expenses.reduce((total, expense) => {
+    const userPaidBy = Array.isArray(expense.paidBy)
+      ? expense.paidBy.find((paidBy) => paidBy.participant.id === activeUserId)
+      : // fallback for old shape
+        ((expense as any).paidBy?.id === activeUserId
+          ? { amount: expense.amount }
+          : undefined)
+    return userPaidBy && !expense.isReimbursement
+      ? total + (userPaidBy as any).amount
+      : total
+  }, 0)
 }
 
 type Expense = NonNullable<Awaited<ReturnType<typeof getGroupExpenses>>>[number]


### PR DESCRIPTION
- port #146 
- Add ExpensePaidBy model and migration to backfill from paidById
- Update API to handle multiple payers; adjust exports, balances, totals
- Update UI: expense form with multi-payer add/remove + total, expense card
- Add i18n keys for participant and total

- BREAKING CHANGE: Expense.paidById removed in favor of ExpensePaidBy.