### PR TITLE
Use "everyone" in the expense card if it was paid for all participants

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -43,6 +43,7 @@
   },
   "ExpenseCard": {
     "paidBy": "Paid by <strong>{paidBy}</strong> for <paidFor></paidFor>",
+    "everyone": "everyone",
     "receivedBy": "Received by <strong>{paidBy}</strong> for <paidFor></paidFor>",
     "yourBalance": "Your balance:"
   },

--- a/messages/nl-NL.json
+++ b/messages/nl-NL.json
@@ -42,6 +42,7 @@
   },
   "ExpenseCard": {
     "paidBy": "Betaald door <strong>{paidBy}</strong> voor <paidFor></paidFor>",
+    "everyone": "iedereen",
     "receivedBy": "Ontvangen door <strong>{paidBy}</strong> voor <paidFor></paidFor>",
     "yourBalance": "Jouw balans:"
   },

--- a/src/app/groups/[groupId]/expenses/expense-card.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-card.tsx
@@ -13,15 +13,27 @@ import { Fragment } from 'react'
 
 type Expense = Awaited<ReturnType<typeof getGroupExpenses>>[number]
 
-function Participants({ expense }: { expense: Expense }) {
+function Participants({
+  expense,
+  participantCount,
+}: {
+  expense: Expense
+  participantCount: number
+}) {
   const t = useTranslations('ExpenseCard')
   const key = expense.amount > 0 ? 'paidBy' : 'receivedBy'
-  const paidFor = expense.paidFor.map((paidFor, index) => (
-    <Fragment key={index}>
-      {index !== 0 && <>, </>}
-      <strong>{paidFor.participant.name}</strong>
-    </Fragment>
-  ))
+  const paidFor =
+    expense.paidFor.length == participantCount && participantCount >= 4 ? (
+      <strong>{t('everyone')}</strong>
+    ) : (
+      expense.paidFor.map((paidFor, index) => (
+        <Fragment key={index}>
+          {index !== 0 && <>, </>}
+          <strong>{paidFor.participant.name}</strong>
+        </Fragment>
+      ))
+    )
+
   const participants = t.rich(key, {
     strong: (chunks) => <strong>{chunks}</strong>,
     paidBy: expense.paidBy.name,
@@ -35,9 +47,15 @@ type Props = {
   expense: Expense
   currency: string
   groupId: string
+  participantCount: number
 }
 
-export function ExpenseCard({ expense, currency, groupId }: Props) {
+export function ExpenseCard({
+  expense,
+  currency,
+  groupId,
+  participantCount,
+}: Props) {
   const router = useRouter()
   const locale = useLocale()
 
@@ -61,7 +79,7 @@ export function ExpenseCard({ expense, currency, groupId }: Props) {
           {expense.title}
         </div>
         <div className="text-xs text-muted-foreground">
-          <Participants expense={expense} />
+          <Participants expense={expense} participantCount={participantCount} />
         </div>
         <div className="text-xs text-muted-foreground">
           <ActiveUserBalance {...{ groupId, currency, expense }} />

--- a/src/app/groups/[groupId]/expenses/expense-list.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-list.tsx
@@ -172,6 +172,7 @@ const ExpenseListForSearch = ({
                 expense={expense}
                 currency={group.currency}
                 groupId={groupId}
+                participantCount={group.participants.length}
               />
             ))}
           </div>


### PR DESCRIPTION
If you have a group with a large number of participants, the expense list becomes cluttered with everyone's names. For most expenses, in my experience, an expense is paid for the whole group, meaning that a lot of the clutter can be erased if you just show "everyone" instead of every participant's name. 

In the current implementation, the minimum number of participants needed for "everyone" to be used is 4, but this can be up for discussion.

## Before
<img width="372" height="322" alt="afbeelding" src="https://github.com/user-attachments/assets/0eea91a3-c86e-447b-98e0-0907dab68324" />

## After
<img width="372" height="278" alt="afbeelding" src="https://github.com/user-attachments/assets/f38b1380-9536-4eb0-8401-cad7e39a6172" />
