### PR TITLE
[BUG] Fix french recurrenceRule translation

### DIFF
--- a/messages/fr-FR.json
+++ b/messages/fr-FR.json
@@ -138,13 +138,13 @@
         "description": "Sélectionnez le participant qui a reçu le revenu."
       },
       "recurrenceRule": {
-        "label": "Expense Recurrence",
-        "description": "Select how often the expense should repeat.",
+        "label": "Récurrence de la dépense",
+        "description": "Sélectionnez la fréquence de répétition de la dépense.",
 
-        "none": "None",
-        "daily": "Daily",
-        "weekly": "Weekly",
-        "monthly": "Monthly"
+        "none": "Aucune",
+        "daily": "Quotidienne",
+        "weekly": "Hebdomadaire",
+        "monthly": "Mensuelle"
       },
       "paidFor": {
         "title": "Reçu pour",
@@ -169,6 +169,15 @@
       "paidByField": {
         "label": "Payé par",
         "description": "Sélectionnez le participant qui a réglé la dépense."
+      },
+      "recurrenceRule": {
+        "label": "Récurrence de la dépense",
+        "description": "Sélectionnez la fréquence de répétition de la dépense.",
+
+        "none": "Aucune",
+        "daily": "Quotidienne",
+        "weekly": "Hebdomadaire",
+        "monthly": "Mensuelle"
       },
       "paidFor": {
         "title": "Payé pour",


### PR DESCRIPTION
There is a translation issue in French for the recurrences. I have added the missing translations and corrected the English part in the fr-FR file.

**Before :**
<img width="423" height="169" alt="Screenshot 2025-09-02 at 10 21 31" src="https://github.com/user-attachments/assets/acaca149-15cc-4908-b1cf-8d1052fee816" />

**After :**
<img width="366" height="166" alt="Screenshot 2025-09-02 at 10 32 09" src="https://github.com/user-attachments/assets/93d39373-2099-49ca-978f-c140c6e0cae0" />

