### PR TITLE
feat: schedule group for deletion

### DIFF
--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -119,7 +119,15 @@
       "saving": "Speichert…",
       "create": "Erstellen",
       "creating": "Erstellt…",
-      "cancel": "Abbrechen"
+      "cancel": "Abbrechen",
+      "Delete": {
+        "title": "Gruppe löschen?",
+        "description": "Das Löschen einer Gruppe führt zu einer 30-tägigen Deaktivierungsphase, nach deren Ablauf alle Daten endgültig gelöscht werden und nicht mehr wiederhergestellt werden können."
+      }
+    },
+    "Delete": {
+      "title": "Gruppe löschen",
+      "description": "Dies führt zu einer 30-tägigen Deaktivierungsphase, nach deren Ablauf alle Daten endgültig gelöscht werden und nicht mehr wiederhergestellt werden können."
     },
     "CurrencyCodeField": {
       "label": "Hauptwährung",
@@ -127,6 +135,16 @@
       "customOption": "benutzerdefiniert",
       "editDescription": "Alle Beträge und Salden werden in dieser Währung angegeben. Bei Änderung dieser, werden bereits eingegebene Ausgaben NICHT umgerechnet, es sei denn, die Währung hat andere \"kleinere Einheiten\" als die aktuelle (z. B. Wechsel von US-Dollar zu Japanischem Yen)"
     }
+  },
+  "DeleteGroupButton": {
+    "title": "Gruppe löschen",
+    "description": "Willst du diese Gruppe wirklich löschen? Gib zum Bestätigen den Gruppennamen ein:",
+    "groupNameField": "Gruppenname"
+  },
+  "DeleteGroupNotice": {
+    "title": "Zur Löschung vorgemerkte Gruppe",
+    "description": "Diese Gruppe wurde zur Löschung vorgemerkt und wird am {date} endgültig gelöscht. Wenn du diese Gruppe reaktivieren möchtest, klicke auf die Schaltfläche unten.",
+    "restore": "Gruppe wiederherstellen"
   },
   "ExpenseForm": {
     "Income": {

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -126,7 +126,21 @@
       "create": "Create",
       "creating": "Creating…",
       "cancel": "Cancel"
+    },
+    "Delete": {
+      "title": "Delete group",
+      "description": "Deleting a group will result in a 30 days deactivation period, after which all data will be permanently deleted and unrecoverable."
     }
+  },
+  "DeleteGroupButton": {
+    "title": "Delete group",
+    "description": "Do you really want to delete this group? To confirm, please enter the group name below.",
+    "groupNameField": "Group name"
+  },
+  "DeleteGroupNotice": {
+    "title": "Group scheduled for deletion",
+    "description": "This group was scheduled for deletion and will be permanently deleted on {date}. If you want to restore it, click the button below.",
+    "restore": "Restore group"
   },
   "ExpenseForm": {
     "Income": {

--- a/prisma/migrations/20250917151818_add_group_delete_at/migration.sql
+++ b/prisma/migrations/20250917151818_add_group_delete_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Group" ADD COLUMN     "deleteAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,6 +21,7 @@ model Group {
   expenses     Expense[]
   activities   Activity[]
   createdAt    DateTime      @default(now())
+  deleteAt     DateTime?
 }
 
 model Participant {

--- a/src/app/groups/[groupId]/delete-group-button.tsx
+++ b/src/app/groups/[groupId]/delete-group-button.tsx
@@ -1,0 +1,56 @@
+'use client'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+Popover,
+PopoverContent,
+PopoverTrigger,
+} from '@/components/ui/popover'
+import { trpc } from '@/trpc/client'
+import { Group } from '@prisma/client'
+import { Trash2 } from 'lucide-react'
+import { useTranslations } from 'next-intl'
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+type Props = {
+  group: Group
+}
+
+
+export function DeleteGroupButton({ group }: Props) {
+  const { mutateAsync } = trpc.groups.delete.useMutation()
+  const t = useTranslations('DeleteGroupButton')
+  const [inputValue, setInputValue] = useState('')
+  const router = useRouter()
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button title={t('title')} variant="destructive">
+          <Trash2 className="w-4 h-4 mr-2" /> {t('title')}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="[&_p]:text-sm flex flex-col gap-3">
+        <p>{t('description')}</p>
+        <div className="flex gap-2">
+          <Input
+            className="flex-1"
+            placeholder={t('groupNameField') + ` (${group.name})`}
+            onChange={e => setInputValue(e.target.value)}
+          />
+        </div>
+        <div className="flex gap-2">
+          <Button
+            variant="destructive"
+            className="flex-1"
+            onClick={() => mutateAsync({ groupId: group.id, groupName: inputValue }).then(() => router.push(`/groups/${group.id}`))}
+            disabled={inputValue !== group.name}
+          >
+            {t('title')}
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/app/groups/[groupId]/delete-group-notice.tsx
+++ b/src/app/groups/[groupId]/delete-group-notice.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import { Card,CardContent,CardDescription,CardHeader,CardTitle } from '@/components/ui/card'
+import { trpc } from '@/trpc/client'
+import { useTranslations } from 'next-intl'
+import { useCurrentGroup } from './current-group-context'
+
+export const DeleteGroupNotice = () => {
+  const { group } = useCurrentGroup()
+  const t = useTranslations('DeleteGroupNotice')
+  const { mutateAsync } = trpc.groups.restore.useMutation()
+
+  return ( group?.deleteAt &&
+    <Card className="border-red-700">
+      <CardHeader>
+        <CardTitle className="text-red-700">{t('title')}</CardTitle>
+        <CardDescription>{
+          t.rich('description', {
+            date: group?.deleteAt?.toLocaleDateString() ?? '',
+          })
+        }</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Button
+          variant="destructive"
+          onClick={() => {
+            mutateAsync({ groupId: group.id }).then(() => window.location.reload())
+          }}
+        >
+          {t('restore')}
+        </Button>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/app/groups/[groupId]/layout.client.tsx
+++ b/src/app/groups/[groupId]/layout.client.tsx
@@ -7,6 +7,7 @@ import { PropsWithChildren, useEffect } from 'react'
 import { CurrentGroupProvider } from './current-group-context'
 import { GroupHeader } from './group-header'
 import { SaveGroupLocally } from './save-recent-group'
+import { DeleteGroupNotice } from '@/app/groups/[groupId]/delete-group-notice'
 
 export function GroupLayoutClient({
   groupId,
@@ -42,6 +43,7 @@ export function GroupLayoutClient({
   return (
     <CurrentGroupProvider {...props}>
       <GroupHeader />
+      <DeleteGroupNotice />
       {children}
       <SaveGroupLocally />
     </CurrentGroupProvider>

--- a/src/app/groups/recent-group-list.tsx
+++ b/src/app/groups/recent-group-list.tsx
@@ -134,6 +134,15 @@ function RecentGroupList_({
     )
   }
 
+  if (data.groups.length !== groups.length) {
+    // Some groups in recent storage are not found in the API response, remove them from recent storage
+    const foundGroupIds = new Set(data.groups.map((group) => group.id))
+    const filteredGroups = groups.filter((group) =>
+      foundGroupIds.has(group.id),
+    )
+    localStorage.setItem('recentGroups', JSON.stringify(filteredGroups))
+  }
+
   const { starredGroupInfo, groupInfo, archivedGroupInfo } = sortGroups({
     groups,
     starredGroups,

--- a/src/components/group-form.tsx
+++ b/src/components/group-form.tsx
@@ -42,6 +42,7 @@ import { useEffect, useState } from 'react'
 import { useFieldArray, useForm } from 'react-hook-form'
 import { CurrencySelector } from './currency-selector'
 import { Textarea } from './ui/textarea'
+import { DeleteGroupButton } from '@/app/groups/[groupId]/delete-group-button'
 
 export type Props = {
   group?: NonNullable<Awaited<ReturnType<typeof getGroup>>>
@@ -357,8 +358,7 @@ export function GroupForm({
             </div>
           </CardContent>
         </Card>
-
-        <div className="flex mt-4 gap-2">
+        <div className="flex mt-4 mb-8 gap-2">
           <SubmitButton
             loadingContent={t(group ? 'Settings.saving' : 'Settings.creating')}
             onClick={updateActiveUser}
@@ -372,7 +372,17 @@ export function GroupForm({
             </Button>
           )}
         </div>
-      </form>
+
+        {group && !group.deleteAt && (<Card className="border-red-700">
+          <CardHeader>
+            <CardTitle className="text-red-700">{t('Delete.title')}</CardTitle>
+            <CardDescription>{t('Delete.description')}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {group && <DeleteGroupButton group={group} />}
+          </CardContent>
+        </Card>)}
+        </form>
     </Form>
   )
 }

--- a/src/trpc/routers/groups/delete.procedure.ts
+++ b/src/trpc/routers/groups/delete.procedure.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod'
+import { scheduleDeleteGroup } from '@/lib/api'
+import { baseProcedure } from '@/trpc/init'
+
+export const deleteGroupProcedure = baseProcedure
+  .input(
+    z.object({
+      groupId: z.string().min(1),
+      groupName: z.string().min(1),
+      participantId: z.string().optional(),
+    }),
+  )
+  .mutation(async ({ input: { groupId, groupName, participantId } }) => {
+    await scheduleDeleteGroup(groupId,groupName, participantId)
+  })

--- a/src/trpc/routers/groups/index.ts
+++ b/src/trpc/routers/groups/index.ts
@@ -8,6 +8,8 @@ import { groupStatsRouter } from '@/trpc/routers/groups/stats'
 import { updateGroupProcedure } from '@/trpc/routers/groups/update.procedure'
 import { getGroupDetailsProcedure } from './getDetails.procedure'
 import { listGroupsProcedure } from './list.procedure'
+import { deleteGroupProcedure } from '@/trpc/routers/groups/delete.procedure'
+import { restoreGroupProcedure } from '@/trpc/routers/groups/restore.procedure'
 
 export const groupsRouter = createTRPCRouter({
   expenses: groupExpensesRouter,
@@ -20,4 +22,6 @@ export const groupsRouter = createTRPCRouter({
   list: listGroupsProcedure,
   create: createGroupProcedure,
   update: updateGroupProcedure,
+  delete: deleteGroupProcedure,
+  restore: restoreGroupProcedure,
 })

--- a/src/trpc/routers/groups/restore.procedure.ts
+++ b/src/trpc/routers/groups/restore.procedure.ts
@@ -1,0 +1,15 @@
+
+import { z } from 'zod'
+import { restoreGroup } from '@/lib/api'
+import { baseProcedure } from '@/trpc/init'
+
+export const restoreGroupProcedure = baseProcedure
+  .input(
+    z.object({
+      groupId: z.string().min(1),
+      participantId: z.string().optional(),
+    }),
+  )
+  .mutation(async ({ input: { groupId } }) => {
+    await restoreGroup(groupId)
+  })


### PR DESCRIPTION
Since #9 has been open for almost 2 years and #186 requests similar functionality, I decided to build a delete function.

With this PR, users are able to schedule a group for deletion, giving them a 30 day grace period to cancel the deletion. This way, users with malicious intent will not be able to instantly delete groups.
There's also a small safety mechanism, forcing users to input the group name. That way, there's no accidental deletion of the wrong group and brute forcing is significantly harder.

One thing that still needs work is the deletion of already uploaded images into the s3 bucket. Help with this is highly appreciated.

(PS: Thank you so much for this app!)