### PR TITLE
fix rounding

### DIFF
--- a/src/lib/balances.ts
+++ b/src/lib/balances.ts
@@ -45,7 +45,7 @@ export function getBalances(
 
       const dividedAmount = isLast
         ? remaining
-        : (expense.amount * shares) / totalShares
+        : Math.round((expense.amount * shares) / totalShares)
       remaining -= dividedAmount
       balances[paidFor.participant.id].paidFor += dividedAmount
     })


### PR DESCRIPTION
**closes #374** 

### Before Fix
$1.00 (100 cents) split among 3 people:

expense.amount = 100 // cents
remaining = 100
paidFors.length = 3 // Johannes, Janina, Jakob

// Person 1 (Johannes) - index 0, isLast = false
dividedAmount = (100 * 1) / 3 = 33.333...
remaining = 100 - 33.333... = 66.666...
Johannes.paidFor += 33.333...

// Person 2 (Janina) - index 1, isLast = false  
dividedAmount = (100 * 1) / 3 = 33.333...
remaining = 66.666... - 33.333... = 33.333...
Janina.paidFor += 33.333...

// Person 3 (Jakob) - index 2, isLast = true
dividedAmount = remaining = 33.333...
remaining = 33.333... - 33.333... = 0
Jakob.paidFor += 33.333...

// Later rounding (lines 57-58)
Johannes.paidFor = Math.round(33.333...) = 33
Janina.paidFor = Math.round(33.333...) = 33  
Jakob.paidFor = Math.round(33.333...) = 33

// RESULT: 33 + 33 + 33 = 99 cents

### After Fix
// Initial state
expense.amount = 100 // cents
remaining = 100
paidFors.length = 3

// Person 1 (Johannes) - index 0, isLast = false
dividedAmount = Math.round((100 * 1) / 3) = Math.round(33.333...) = 33
remaining = 100 - 33 = 67
Johannes.paidFor += 33

// Person 2 (Janina) - index 1, isLast = false
dividedAmount = Math.round((100 * 1) / 3) = Math.round(33.333...) = 33
remaining = 67 - 33 = 34
Janina.paidFor += 33

// Person 3 (Jakob) - index 2, isLast = true
dividedAmount = remaining = 34  // Gets the leftover!
remaining = 34 - 34 = 0
Jakob.paidFor += 34

// No additional rounding needed since we already rounded during calculation

// RESULT: 33 + 33 + 34 = 100 cents