### PR TITLE
feat: Add expense category 'Life/Beauty'

### DIFF
--- a/messages/ca.json
+++ b/messages/ca.json
@@ -364,6 +364,7 @@
     },
     "Life": {
       "heading": "Vida",
+      "Beauty": "Bellesa",
       "Childcare": "Cura de criatures",
       "Clothing": "Roba",
       "Education": "Ensenyament",

--- a/messages/cs-CZ.json
+++ b/messages/cs-CZ.json
@@ -364,6 +364,7 @@
     },
     "Life": {
       "heading": "Život",
+      "Beauty": "Krása",
       "Childcare": "Péče o děti",
       "Clothing": "Oblečení",
       "Donation": "Dar",

--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -381,6 +381,7 @@
     },
     "Life": {
       "heading": "Leben",
+      "Beauty": "Schönheit",
       "Childcare": "Kinderversorgung",
       "Clothing": "Kleidung",
       "Donation": "Spende",

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -404,6 +404,7 @@
     },
     "Life": {
       "heading": "Life",
+      "Beauty": "Beauty",
       "Childcare": "Childcare",
       "Clothing": "Clothing",
       "Donation": "Donation",

--- a/messages/es.json
+++ b/messages/es.json
@@ -364,6 +364,7 @@
     },
     "Life": {
       "heading": "Vida",
+      "Beauty": "Belleza",
       "Childcare": "Cuidado de niños",
       "Clothing": "Ropa",
       "Education": "Educación",

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -345,6 +345,7 @@
     },
     "Life": {
       "heading": "Elämä",
+      "Beauty": "Kauneus",
       "Childcare": "Lastenhoito",
       "Clothing": "Vaatteet",
       "Education": "Opiskelu",

--- a/messages/fr-FR.json
+++ b/messages/fr-FR.json
@@ -403,6 +403,7 @@
     },
     "Life": {
       "heading": "Vie",
+      "Beauty": "Beauté",
       "Childcare": "Garde d'enfants",
       "Clothing": "Vêtements",
       "Education": "Éducation",

--- a/messages/it-IT.json
+++ b/messages/it-IT.json
@@ -375,6 +375,7 @@
     },
     "Life": {
       "heading": "Vita",
+      "Beauty": "Bellezza",
       "Childcare": "Cura dei bambini",
       "Clothing": "Abbigliamento",
       "Donation": "Donazioni",

--- a/messages/ja-JP.json
+++ b/messages/ja-JP.json
@@ -364,6 +364,7 @@
     },
     "Life": {
       "heading": "生活",
+      "Beauty": "美容",
       "Childcare": "育児",
       "Clothing": "衣類",
       "Donation": "寄付",

--- a/messages/nl-NL.json
+++ b/messages/nl-NL.json
@@ -411,6 +411,7 @@
     },
     "Life": {
       "heading": "Leven",
+      "Beauty": "Schoonheid",
       "Childcare": "Kinderopvang",
       "Clothing": "Kleding",
       "Donation": "Donatie",

--- a/messages/pl-PL.json
+++ b/messages/pl-PL.json
@@ -364,6 +364,7 @@
     },
     "Life": {
       "heading": "Życie",
+      "Beauty": "Uroda",
       "Childcare": "Opieka nad dzieckiem",
       "Clothing": "Ubrania",
       "Donation": "Darowizna",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -373,6 +373,7 @@
     },
     "Life": {
       "heading": "Vida",
+      "Beauty": "Beleza",
       "Childcare": "Cuidados infantis",
       "Clothing": "Roupas",
       "Education": "Educação",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -355,6 +355,7 @@
     },
     "Life": {
       "heading": "Viață",
+      "Beauty": "Frumusețe",
       "Childcare": "Îngrijirea copiilor",
       "Clothing": "Îmbrăcăminte",
       "Education": "Educație",

--- a/messages/ru-RU.json
+++ b/messages/ru-RU.json
@@ -355,6 +355,7 @@
     },
     "Life": {
       "heading": "Жизнь",
+      "Beauty": "Красота",
       "Childcare": "Дети",
       "Clothing": "Одежда",
       "Education": "Образование",

--- a/messages/tr-TR.json
+++ b/messages/tr-TR.json
@@ -355,6 +355,7 @@
     },
     "Life": {
       "heading": "Yaşam",
+      "Beauty": "Güzellik",
       "Childcare": "Çocuk Bakımı",
       "Clothing": "Giyim",
       "Education": "Eğitim",

--- a/messages/ua-UA.json
+++ b/messages/ua-UA.json
@@ -355,6 +355,7 @@
     },
     "Life": {
       "heading": "Життя",
+      "Beauty": "Краса",
       "Childcare": "Догляд за дітьми",
       "Clothing": "Одяг",
       "Education": "Освіта",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -355,6 +355,7 @@
     },
     "Life": {
       "heading": "生活",
+      "Beauty": "美容",
       "Childcare": "儿童保育",
       "Clothing": "衣物",
       "Education": "教育",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -355,6 +355,7 @@
     },
     "Life": {
       "heading": "生活",
+      "Beauty": "美容",
       "Childcare": "育兒",
       "Clothing": "衣服",
       "Education": "教育",

--- a/prisma/migrations/20251101155000_add_category_beauty/migration.sql
+++ b/prisma/migrations/20251101155000_add_category_beauty/migration.sql
@@ -1,0 +1,1 @@
+INSERT INTO "Category" ("id", "grouping", "name") VALUES (44, 'Life', 'Beauty');

--- a/src/app/groups/[groupId]/expenses/category-icon.tsx
+++ b/src/app/groups/[groupId]/expenses/category-icon.tsx
@@ -39,6 +39,7 @@ import {
   Train,
   Trash,
   Utensils,
+  WandSparkles,
   Wine,
   Wrench,
 } from 'lucide-react'
@@ -99,6 +100,8 @@ function getCategoryIcon(category: string): LucideIcon {
       return Shirt
     case 'Life/Donation':
       return HandHelping
+    case 'Life/Beauty':
+      return WandSparkles
     case 'Life/Education':
       return LibraryBig
     case 'Life/Gifts':


### PR DESCRIPTION
Similar to #315. This PR adds a new "Beauty" expense category under the "Life" grouping to better categorize beauty-related expenses (cosmetics, salon visits, personal care, etc.).

### Motivation
In the current version, expenses like facial treatments, makeup products, and beauty services are categorized into Medical expenses, General, or Clothing. With this change, they'll be properly identified in the Beauty category, providing more accurate expense tracking and reporting.

### Changes
- Added new `Life/Beauty` category to the database via migration
- Added `WandSparkles` icon (from lucide-react) for the Beauty category
- Added localized translations for "Beauty" across all 19 supported languages:
  - English, French, German, Spanish, Italian, Dutch, Portuguese, Polish, Russian, Ukrainian, Czech, Romanian, Turkish, Finnish, Catalan, Japanese, Chinese (Simplified & Traditional)

### Migration
- Database migration `20251101155000_add_category_beauty` inserts the new category with ID 44

This enhancement provides users with a more specific categorization option for beauty and personal care expenses that were previously uncategorized or grouped under generic categories.


### Reference
**With this change - Facial treatment categorized as Beauty:**
<img width="715" height="297" alt="Screenshot 2025-11-02 at 17 37 19" src="https://github.com/user-attachments/assets/43a818f9-c8dd-442c-b733-ee3ae053f63d" />

**Current version - Facial treatment categorized as Medical:**
<img width="710" height="294" alt="Screenshot 2025-11-02 at 17 38 28" src="https://github.com/user-attachments/assets/ce8160aa-d44b-4b92-a78a-e64d15d0f412" />

