### PR TITLE
Add cascade delete for Activity records when Group is deleted

### DIFF
--- a/prisma/migrations/20251103161018_add_ondelete_cascade_to_activity_groupid/migration.sql
+++ b/prisma/migrations/20251103161018_add_ondelete_cascade_to_activity_groupid/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE "Activity" DROP CONSTRAINT "Activity_groupId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "Activity" ADD CONSTRAINT "Activity_groupId_fkey" FOREIGN KEY ("groupId") REFERENCES "Group"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -116,7 +116,7 @@ model ExpensePaidFor {
 
 model Activity {
   id            String       @id
-  group         Group        @relation(fields: [groupId], references: [id])
+  group         Group        @relation(fields: [groupId], references: [id], onDelete: Cascade)
   groupId       String
   time          DateTime     @default(now())
   activityType  ActivityType


### PR DESCRIPTION
## Summary
Adds `onDelete: Cascade` behavior to the Activity-Group relationship to automatically clean up activity records when a group is deleted.

## Changes
- Updated the `Activity.group` relation in the Prisma schema to include `onDelete: Cascade`
- Added database migration to update the foreign key constraint on the `Activity` table

## Motivation
When cleaning up test groups in the database, deleting them directly from the Group table was prohibited by the foreign key constraint in the Activity table. This change improves the deletion workflow by allowing groups to be deleted directly, while also preventing orphaned Activity records through cascade delete behavior.

<img width="893" height="242" alt="Screenshot 2025-11-03 111110" src="https://github.com/user-attachments/assets/df5bdc64-009c-4662-bea4-bd9dbeb294fb" />


## Technical Details
- Modified foreign key constraint: `Activity_groupId_fkey`
- Database operation: `ON DELETE CASCADE` now applies to the Activity-Group relationship
- The migration safely drops and recreates the constraint with the new behavior

## Testing
- [x] Verify that deleting a group also removes all associated activities
- [x] Confirm no orphaned activity records remain after group deletion
- [x] Check that normal CRUD operations on activities still work as expected

## Migration Notes
This change includes a database migration that will run automatically. The migration:
1. Drops the existing `Activity_groupId_fkey` constraint
2. Recreates it with `ON DELETE CASCADE ON UPDATE CASCADE`