### PR TITLE
fix(db): Correct local db script volume mount for modern postgres images

### DIFF
--- a/scripts/start-local-db.sh
+++ b/scripts/start-local-db.sh
@@ -6,6 +6,6 @@ else
     echo "postgres is not running, starting it"
     docker rm postgres --force
     mkdir -p postgres-data
-    docker run --name spliit-db -d -p 5432:5432 -e POSTGRES_PASSWORD=1234 -v "/$(pwd)/postgres-data:/var/lib/postgresql/data" postgres
+    docker run --name spliit-db -d -p 5432:5432 -e POSTGRES_PASSWORD=1234 -v "/$(pwd)/postgres-data:/var/lib/postgresql" postgres
     sleep 5 # Wait for postgres to start
 fi


### PR DESCRIPTION

### Description

This PR provides a minimal fix for the `scripts/start-local-db.sh` script, which was failing when used with modern PostgreSQL Docker images (version 18+).

The root cause of the failure was an incorrect volume mount point in the `docker run` command. The script was attempting to mount the PostgreSQL data volume to `/var/lib/postgresql/data`, while newer PostgreSQL images expect the mount point to be at `/var/lib/postgresql`. This discrepancy caused the container to exit with an error, preventing local database setup.

This commit addresses the issue by:
- Changing the volume mount in `scripts/start-local-db.sh` from `/var/lib/postgresql/data` to `/var/lib/postgresql`.

This is a targeted and minimal fix that resolves the immediate problem of the script failing. Other aspects of the script, such as its container management logic, remain unchanged to keep this PR focused.

### Related Issue

Fixes #459

### How to Test

1.  Ensure you have a recent version of Docker installed.
2.  Run the `scripts/start-local-db.sh` script.
3.  Verify that the `spliit-db` PostgreSQL container starts successfully and remains running.
4.  You can check the container's status with `docker ps` and its logs with `docker logs spliit-db`.