### PR TITLE
feat: add multi-payer expense support

### DIFF
--- a/messages/ca.json
+++ b/messages/ca.json
@@ -43,6 +43,7 @@
   },
   "ExpenseCard": {
     "paidBy": "Pagada per <strong>{paidBy}</strong> per a <paidFor></paidFor>",
+    "paidByMultiple": "Pagat per <paidByNames></paidByNames> per a <paidFor></paidFor>",
     "receivedBy": "Debuda per <strong>{paidBy}</strong> para <paidFor></paidFor>",
     "yourBalance": "El teu balanç: balance:",
     "everyone": "totes",
@@ -260,6 +261,15 @@
       "dateMismatch": "Tases per a la data: {date}",
       "refresh": "Refrescar",
       "customRate": "Emprant tasa personalitzada"
+    },
+    "multiPayer": "Múltiples pagadors",
+    "multiPayerToggle": "Divideix el pagament entre múltiples participants",
+    "paidByCard": {
+      "title": "Pagat per",
+      "description": "Selecciona qui ha pagat aquesta despesa i com dividir el pagament."
+    },
+    "PaidBySplitModeField": {
+      "label": "Mode de divisió del pagador"
     }
   },
   "ExpenseDocumentsInput": {
@@ -372,7 +382,9 @@
     "noZeroShares": "Totes les participacions han de ser superiors a 0",
     "amountSum": "La suma dels imports ha de ser igual a la suma de la despesa",
     "percentageSum": "La suma dels percentatges ha de ser igual a 100",
-    "ratePositive": "La tasa ha de ser estrictament major que zero."
+    "ratePositive": "La tasa ha de ser estrictament major que zero.",
+    "paidByAmountSum": "La suma dels imports dels pagadors ha de ser igual a l'import de la despesa.",
+    "paidByPercentageSum": "La suma dels percentatges dels pagadors ha de ser igual a 100."
   },
   "Categories": {
     "search": "Cercar categoria...",

--- a/messages/cs-CZ.json
+++ b/messages/cs-CZ.json
@@ -43,6 +43,7 @@
   },
   "ExpenseCard": {
     "paidBy": "Zaplatil/a <strong>{paidBy}</strong> za <paidFor></paidFor>",
+    "paidByMultiple": "Zaplatil(a) <paidByNames></paidByNames> za <paidFor></paidFor>",
     "receivedBy": "Obdržel/a <strong>{paidBy}</strong> od <paidFor></paidFor>",
     "yourBalance": "Váš zůstatek:"
   },
@@ -214,7 +215,16 @@
     "save": "Uložit",
     "saving": "Ukládání…",
     "cancel": "Zrušit",
-    "reimbursement": "Proplacení"
+    "reimbursement": "Proplacení",
+    "multiPayer": "Více plátců",
+    "multiPayerToggle": "Rozdělit platbu mezi více účastníků",
+    "paidByCard": {
+      "title": "Zaplaceno",
+      "description": "Vyberte, kdo za tento výdaj zaplatil a jak rozdělit platbu."
+    },
+    "PaidBySplitModeField": {
+      "label": "Režim rozdělení plátce"
+    }
   },
   "ExpenseDocumentsInput": {
     "TooBigToast": {
@@ -325,7 +335,9 @@
     "paidForMin1": "Výdaj musí být zaplacen alespoň za jednoho účastníka.",
     "noZeroShares": "Všechny podíly musí být větší než 0.",
     "amountSum": "Součet částek se musí rovnat částce výdaje.",
-    "percentageSum": "Součet procent musí být 100."
+    "percentageSum": "Součet procent musí být 100.",
+    "paidByAmountSum": "Součet částek plátců musí odpovídat celkové částce výdaje.",
+    "paidByPercentageSum": "Součet procent plátců musí být roven 100."
   },
   "Categories": {
     "search": "Hledat kategorii...",

--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -43,6 +43,7 @@
   },
   "ExpenseCard": {
     "paidBy": "Gezahlt von <strong>{paidBy}</strong> für <paidFor></paidFor>",
+    "paidByMultiple": "Bezahlt von <paidByNames></paidByNames> für <paidFor></paidFor>",
     "receivedBy": "Empfangen von <strong>{paidBy}</strong> für <paidFor></paidFor>",
     "yourBalance": "Deine Bilanz:",
     "everyone": "jeder",
@@ -260,6 +261,15 @@
       "useCustom": "Benutze individuelle Rate",
       "label": "Wechselkurs",
       "useApi": "Benutze Zinssätze von Frankfurter"
+    },
+    "multiPayer": "Mehrere Zahler",
+    "multiPayerToggle": "Zahlung auf mehrere Teilnehmer aufteilen",
+    "paidByCard": {
+      "title": "Bezahlt von",
+      "description": "Wähle aus, wer diese Ausgabe bezahlt hat und wie die Zahlung aufgeteilt werden soll."
+    },
+    "PaidBySplitModeField": {
+      "label": "Zahlungsaufteilungsmodus"
     }
   },
   "ExpenseDocumentsInput": {
@@ -372,7 +382,9 @@
     "noZeroShares": "Alle Anteile müssen größer als 0 sein.",
     "amountSum": "Die Summe der Beträge muss dem Betrag der Ausgabe entsprechen.",
     "percentageSum": "Die Summe der prozentualen Anteile muss 100 ergeben.",
-    "ratePositive": "Der Zinssatz muss unbedingt größer als Null sein."
+    "ratePositive": "Der Zinssatz muss unbedingt größer als Null sein.",
+    "paidByAmountSum": "Die Summe der Zahlerbeträge muss dem Ausgabenbetrag entsprechen.",
+    "paidByPercentageSum": "Die Summe der Zahlerprozentsätze muss 100 ergeben."
   },
   "Categories": {
     "search": "Nach Kategorie suchen...",

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -43,6 +43,7 @@
   },
   "ExpenseCard": {
     "paidBy": "Paid by <strong>{paidBy}</strong> for <paidFor></paidFor>",
+    "paidByMultiple": "Paid by <paidByNames></paidByNames> for <paidFor></paidFor>",
     "everyone": "everyone",
     "receivedBy": "Received by <strong>{paidBy}</strong> for <paidFor></paidFor>",
     "yourBalance": "Your balance:",
@@ -231,6 +232,15 @@
     "selectNone": "Select none",
     "selectAll": "Select all",
     "shares": "share(s)",
+    "multiPayer": "Multiple payers",
+    "multiPayerToggle": "Split the payment between multiple participants",
+    "paidByCard": {
+      "title": "Paid by",
+      "description": "Select who paid for this expense and how to split the payment."
+    },
+    "PaidBySplitModeField": {
+      "label": "Payer split mode"
+    },
     "advancedOptions": "Advanced splitting options…",
     "SplitModeField": {
       "label": "Split mode",
@@ -365,7 +375,9 @@
     "paidForMin1": "The expense must be paid for at least one participant.",
     "noZeroShares": "All shares must be higher than 0.",
     "amountSum": "Sum of amounts must equal the expense amount.",
-    "percentageSum": "Sum of percentages must equal 100."
+    "percentageSum": "Sum of percentages must equal 100.",
+    "paidByAmountSum": "Sum of payer amounts must equal the expense amount.",
+    "paidByPercentageSum": "Sum of payer percentages must equal 100."
   },
   "Categories": {
     "search": "Search category...",

--- a/messages/es.json
+++ b/messages/es.json
@@ -43,6 +43,7 @@
   },
   "ExpenseCard": {
     "paidBy": "Pagado por <strong>{paidBy}</strong> para <paidFor></paidFor>",
+    "paidByMultiple": "Pagado por <paidByNames></paidByNames> para <paidFor></paidFor>",
     "receivedBy": "Recibido por <strong>{paidBy}</strong> para <paidFor></paidFor>",
     "yourBalance": "Tu balance:",
     "everyone": "todos",
@@ -252,6 +253,15 @@
       "dateMismatch": "Tasas para la fecha: {date}",
       "refresh": "Actualizar",
       "customRate": "Utilizando tasa personalizada"
+    },
+    "multiPayer": "Múltiples pagadores",
+    "multiPayerToggle": "Dividir el pago entre múltiples participantes",
+    "paidByCard": {
+      "title": "Pagado por",
+      "description": "Selecciona quién pagó este gasto y cómo dividir el pago."
+    },
+    "PaidBySplitModeField": {
+      "label": "Modo de división del pagador"
     }
   },
   "ExpenseDocumentsInput": {
@@ -364,7 +374,9 @@
     "noZeroShares": "Todas las partes deben ser mayor que 0.",
     "amountSum": "La suma de los importes debe ser igual al importe del gasto total.",
     "percentageSum": "Suma de porcentajes debe ser igual a 100.",
-    "ratePositive": "La tasa debe ser mayor a cero."
+    "ratePositive": "La tasa debe ser mayor a cero.",
+    "paidByAmountSum": "La suma de los importes de los pagadores debe ser igual al importe del gasto.",
+    "paidByPercentageSum": "La suma de los porcentajes de los pagadores debe ser igual a 100."
   },
   "Categories": {
     "search": "Buscar categoría...",

--- a/messages/eu.json
+++ b/messages/eu.json
@@ -43,6 +43,7 @@
   },
   "ExpenseCard": {
     "paidBy": "<strong>{paidBy}</strong>-k ordaindua <paidFor></paidFor>-rentzat",
+    "paidByMultiple": "Ordaindua <paidByNames></paidByNames>(e)k <paidFor></paidFor>(e)ntzat",
     "everyone": "denak",
     "receivedBy": "<strong>{paidBy}</strong>-k jasota <paidFor></paidFor>-rentzat",
     "yourBalance": "Zure saldoa:",
@@ -252,7 +253,16 @@
     "save": "Gorde",
     "saving": "Gordetzen…",
     "cancel": "Utzi",
-    "reimbursement": "Diru-itzultzea"
+    "reimbursement": "Diru-itzultzea",
+    "multiPayer": "Ordaintzaile anitzak",
+    "multiPayerToggle": "Banatu ordainketa parte-hartzaile anitzen artean",
+    "paidByCard": {
+      "title": "Ordaindua",
+      "description": "Aukeratu nork ordaindu duen gastu hau eta nola banatu ordainketa."
+    },
+    "PaidBySplitModeField": {
+      "label": "Ordaintzailearen banaketa modua"
+    }
   },
   "ExpenseDocumentsInput": {
     "TooBigToast": {
@@ -364,7 +374,9 @@
     "paidForMin1": "Gastua gutxienez kide batek ordaindu behar du.",
     "noZeroShares": "Parte guztiek zero baino handiagoak izan behar dute.",
     "amountSum": "Zenbatekoen baturak gastuaren zenbatekoa berdindu behar du.",
-    "percentageSum": "Ehunekoen baturak 100 izan behar du."
+    "percentageSum": "Ehunekoen baturak 100 izan behar du.",
+    "paidByAmountSum": "Ordaintzaileen kopuruen baturak gastuaren zenbatekoaren berdina izan behar du.",
+    "paidByPercentageSum": "Ordaintzaileen ehunekoen baturak 100 izan behar du."
   },
   "Categories": {
     "search": "Bilatu kategoria...",

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -42,6 +42,7 @@
   },
   "ExpenseCard": {
     "paidBy": "<strong>{paidBy}</strong> maksoi {forCount, plural, =1 {henkilön} other {henkilöiden}} <paidFor></paidFor> puolesta",
+    "paidByMultiple": "Maksajat <paidByNames></paidByNames>, kohde <paidFor></paidFor>",
     "receivedBy": "<strong>{paidBy}</strong> sai rahaa {forCount, plural, =1 {henkilön} other {henkilöiden}} <paidFor></paidFor> puolesta",
     "yourBalance": "Saldosi:"
   },
@@ -205,7 +206,16 @@
     "save": "Tallenna",
     "saving": "Tallennetaan…",
     "cancel": "Peruuta",
-    "reimbursement": "Velanmaksu"
+    "reimbursement": "Velanmaksu",
+    "multiPayer": "Useita maksajia",
+    "multiPayerToggle": "Jaa maksu useiden osallistujien kesken",
+    "paidByCard": {
+      "title": "Maksaja",
+      "description": "Valitse kuka maksoi tämän kulun ja miten maksu jaetaan."
+    },
+    "PaidBySplitModeField": {
+      "label": "Maksajan jakotapa"
+    }
   },
   "ExpenseDocumentsInput": {
     "TooBigToast": {
@@ -306,7 +316,9 @@
     "paidForMin1": "Valitse vähintään yksi osallistuja.",
     "noZeroShares": "Jokaisen osuuden täytyy olla suurempi kuin 0.",
     "amountSum": "Osuuksien summan täytyy vastata kulun summaa.",
-    "percentageSum": "Prosenttiosuuksien summan täytyy olla 100."
+    "percentageSum": "Prosenttiosuuksien summan täytyy olla 100.",
+    "paidByAmountSum": "Maksajien summien on vastattava kulun kokonaismäärää.",
+    "paidByPercentageSum": "Maksajien prosenttien summan on oltava 100."
   },
   "Categories": {
     "search": "Etsi kategoriaa...",

--- a/messages/fr-FR.json
+++ b/messages/fr-FR.json
@@ -43,6 +43,7 @@
   },
   "ExpenseCard": {
     "paidBy": "Payé par <strong>{paidBy}</strong> pour <paidFor></paidFor>",
+    "paidByMultiple": "Payé par <paidByNames></paidByNames> pour <paidFor></paidFor>",
     "receivedBy": "Reçu par <strong>{paidBy}</strong> pour <paidFor></paidFor>",
     "yourBalance": "Votre solde :",
     "everyone": "tout le monde",
@@ -260,6 +261,15 @@
       "noDate": "Saisissez la date de la dépense pour obtenir un taux de change.",
       "dateMismatch": "Taux de change le {date}",
       "customRate": "Utilisation d’un taux personnalisé"
+    },
+    "multiPayer": "Plusieurs payeurs",
+    "multiPayerToggle": "Répartir le paiement entre plusieurs participants",
+    "paidByCard": {
+      "title": "Payé par",
+      "description": "Sélectionnez qui a payé cette dépense et comment répartir le paiement."
+    },
+    "PaidBySplitModeField": {
+      "label": "Mode de répartition des payeurs"
     }
   },
   "ExpenseDocumentsInput": {
@@ -372,7 +382,9 @@
     "noZeroShares": "Toutes les parts doivent être supérieures à 0.",
     "amountSum": "La somme des montants doit être égale au montant de la dépense.",
     "percentageSum": "La somme des pourcentages doit être égale à 100.",
-    "ratePositive": "Le taux de change doit être strictement supérieur à zéro."
+    "ratePositive": "Le taux de change doit être strictement supérieur à zéro.",
+    "paidByAmountSum": "La somme des montants des payeurs doit être égale au montant de la dépense.",
+    "paidByPercentageSum": "La somme des pourcentages des payeurs doit être égale à 100."
   },
   "Categories": {
     "search": "Rechercher une catégorie…",

--- a/messages/he.json
+++ b/messages/he.json
@@ -43,6 +43,7 @@
   },
   "ExpenseCard": {
     "paidBy": "שולם על ידי <strong>{paidBy}</strong> עבור <paidFor></paidFor>",
+    "paidByMultiple": "שולם על ידי <paidByNames></paidByNames> עבור <paidFor></paidFor>",
     "everyone": "כולם",
     "receivedBy": "התקבל על ידי <strong>{paidBy}</strong> עבור <paidFor></paidFor>",
     "yourBalance": "היתרה שלך:",
@@ -252,7 +253,16 @@
     "save": "שמור",
     "saving": "שומר…",
     "cancel": "ביטול",
-    "reimbursement": "החזר"
+    "reimbursement": "החזר",
+    "multiPayer": "משלמים מרובים",
+    "multiPayerToggle": "חלק את התשלום בין מספר משתתפים",
+    "paidByCard": {
+      "title": "שולם על ידי",
+      "description": "בחר מי שילם על הוצאה זו וכיצד לחלק את התשלום."
+    },
+    "PaidBySplitModeField": {
+      "label": "מצב חלוקת משלם"
+    }
   },
   "ExpenseDocumentsInput": {
     "TooBigToast": {
@@ -364,7 +374,9 @@
     "paidForMin1": "ההוצאה חייבת להיות משולמת עבור לפחות משתתף אחד.",
     "noZeroShares": "כל חלקי ההשתתפות חייבים להיות גבוהים מ-0.",
     "amountSum": "סיכום הסכומים חייב להיות שווה לסכום ההוצאה.",
-    "percentageSum": "סיכום האחוזים חייב להיות שווה ל-100."
+    "percentageSum": "סיכום האחוזים חייב להיות שווה ל-100.",
+    "paidByAmountSum": "סכום סכומי המשלמים חייב להיות שווה לסכום ההוצאה.",
+    "paidByPercentageSum": "סכום אחוזי המשלמים חייב להיות שווה ל-100."
   },
   "Categories": {
     "search": "חפש קטגוריה...",

--- a/messages/id.json
+++ b/messages/id.json
@@ -43,6 +43,7 @@
   },
   "ExpenseCard": {
     "paidBy": "Dibayar oleh <strong>{paidBy}</strong> untuk <paidFor></paidFor>",
+    "paidByMultiple": "Dibayar oleh <paidByNames></paidByNames> untuk <paidFor></paidFor>",
     "everyone": "semua orang",
     "receivedBy": "Diterima oleh <strong>{paidBy}</strong> untuk <paidFor></paidFor>",
     "yourBalance": "Saldo Anda:",
@@ -252,7 +253,16 @@
     "save": "Simpan",
     "saving": "Menyimpan…",
     "cancel": "Batalkan",
-    "reimbursement": "Reimburse"
+    "reimbursement": "Reimburse",
+    "multiPayer": "Beberapa pembayar",
+    "multiPayerToggle": "Bagi pembayaran antara beberapa peserta",
+    "paidByCard": {
+      "title": "Dibayar oleh",
+      "description": "Pilih siapa yang membayar pengeluaran ini dan cara membagi pembayaran."
+    },
+    "PaidBySplitModeField": {
+      "label": "Mode pembagian pembayar"
+    }
   },
   "Currencies": {
     "custom": {
@@ -377,7 +387,9 @@
     "paidForMin1": "Pengeluaran harus dibayarkan untuk setidaknya satu peserta.",
     "noZeroShares": "Semua porsi harus lebih tinggi dari 0.",
     "amountSum": "Total harus sama dengan jumlah pengeluaran.",
-    "percentageSum": "Total persentase harus sama dengan 100."
+    "percentageSum": "Total persentase harus sama dengan 100.",
+    "paidByAmountSum": "Jumlah nominal pembayar harus sama dengan jumlah pengeluaran.",
+    "paidByPercentageSum": "Jumlah persentase pembayar harus sama dengan 100."
   },
   "Categories": {
     "search": "Cari kategori...",

--- a/messages/it-IT.json
+++ b/messages/it-IT.json
@@ -43,6 +43,7 @@
   },
   "ExpenseCard": {
     "paidBy": "Pagato da <strong>{paidBy}</strong> per <paidFor></paidFor>",
+    "paidByMultiple": "Pagato da <paidByNames></paidByNames> per <paidFor></paidFor>",
     "receivedBy": "Ricevuto da <strong>{paidBy}</strong> per <paidFor></paidFor>",
     "yourBalance": "Il tuo saldo:",
     "notInvolved": "Non sei coinvolto",
@@ -228,6 +229,15 @@
     "reimbursement": "Rimborso",
     "conversionRateState": {
       "refresh": "Aggiornare"
+    },
+    "multiPayer": "Più paganti",
+    "multiPayerToggle": "Dividi il pagamento tra più partecipanti",
+    "paidByCard": {
+      "title": "Pagato da",
+      "description": "Seleziona chi ha pagato questa spesa e come dividere il pagamento."
+    },
+    "PaidBySplitModeField": {
+      "label": "Modalità di divisione del pagante"
     }
   },
   "ExpenseDocumentsInput": {
@@ -339,7 +349,9 @@
     "paidForMin1": "La spesa deve essere pagata per almeno un partecipante.",
     "noZeroShares": "Tutti gli importi devono essere superiori a 0.",
     "amountSum": "La somma degli importi deve essere uguale all'importo della spesa.",
-    "percentageSum": "La somma delle percentuali deve essere uguale a 100."
+    "percentageSum": "La somma delle percentuali deve essere uguale a 100.",
+    "paidByAmountSum": "La somma degli importi dei paganti deve essere uguale all'importo della spesa.",
+    "paidByPercentageSum": "La somma delle percentuali dei paganti deve essere uguale a 100."
   },
   "Categories": {
     "search": "Cerca categoria...",

--- a/messages/ja-JP.json
+++ b/messages/ja-JP.json
@@ -43,6 +43,7 @@
   },
   "ExpenseCard": {
     "paidBy": "<strong>{paidBy}</strong>が<paidFor></paidFor>のために支払いました",
+    "paidByMultiple": "<paidByNames></paidByNames>が<paidFor></paidFor>のために支払い",
     "receivedBy": "<strong>{paidBy}</strong>が<paidFor></paidFor>のために受け取りました",
     "yourBalance": "あなたの残高:",
     "everyone": "全員",
@@ -232,6 +233,15 @@
     "saving": "保存中…",
     "cancel": "キャンセル",
     "reimbursement": "払い戻し",
+    "multiPayer": "複数の支払者",
+    "multiPayerToggle": "支払いを複数の参加者で分割する",
+    "paidByCard": {
+      "title": "支払者",
+      "description": "この支出を誰が支払い、どのように分割するかを選択してください。"
+    },
+    "PaidBySplitModeField": {
+      "label": "支払者の分割モード"
+    },
     "conversionUnavailable": "支出ごとに異なる通貨を設定して金額を換算するには、グループの通貨をカスタム以外の通貨に設定してください。",
     "originalAmountField": {
       "label": "換算する金額"
@@ -364,6 +374,8 @@
     "noZeroShares": "すべてのシェアは0より大きくなければなりません。",
     "amountSum": "金額の合計は支出金額と一致する必要があります。",
     "percentageSum": "パーセンテージの合計は100である必要があります。",
+    "paidByAmountSum": "支払者の金額の合計は支出金額と一致する必要があります。",
+    "paidByPercentageSum": "支払者の割合の合計は100になる必要があります。",
     "ratePositive": "レートは必ずゼロより大きくなければなりません。"
   },
   "Categories": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -184,7 +184,16 @@
       }
     },
     "reimbursement": "정산",
-    "cancel": "취소"
+    "cancel": "취소",
+    "multiPayer": "다중 결제자",
+    "multiPayerToggle": "여러 참가자 간에 결제를 분할",
+    "paidByCard": {
+      "title": "결제자",
+      "description": "이 지출을 누가 결제했는지와 결제 분할 방법을 선택하세요."
+    },
+    "PaidBySplitModeField": {
+      "label": "결제자 분할 모드"
+    }
   },
   "Balances": {
     "title": "잔액",
@@ -238,6 +247,8 @@
     "noZeroShares": "각 몫은 0보다 커야 합니다.",
     "amountSum": "금액 합계가 지출 금액과 같아야 해요.",
     "percentageSum": "퍼센트 합이 100이 되어야 합니다.",
+    "paidByAmountSum": "결제자 금액의 합계는 지출 금액과 같아야 합니다.",
+    "paidByPercentageSum": "결제자 비율의 합계는 100이어야 합니다.",
     "min1": "최소 한 글자 이상 입력해 주세요.",
     "min2": "최소 두 글자 이상 입력해 주세요.",
     "titleRequired": "제목을 입력해 주세요."
@@ -335,6 +346,7 @@
   },
   "ExpenseCard": {
     "paidBy": "<strong>{paidBy}</strong>가 <paidFor></paidFor>를 위해 결제함",
+    "paidByMultiple": "<paidByNames></paidByNames>이(가) <paidFor></paidFor>을(를) 위해 결제",
     "everyone": "모두",
     "yourBalance": "내 잔액:",
     "notInvolved": "당신은 관련이 없어요"

--- a/messages/nl-NL.json
+++ b/messages/nl-NL.json
@@ -43,6 +43,7 @@
   },
   "ExpenseCard": {
     "paidBy": "Betaald door <strong>{paidBy}</strong> voor <paidFor></paidFor>",
+    "paidByMultiple": "Betaald door <paidByNames></paidByNames> voor <paidFor></paidFor>",
     "everyone": "iedereen",
     "receivedBy": "Ontvangen door <strong>{paidBy}</strong> voor <paidFor></paidFor>",
     "yourBalance": "Jouw balans:",
@@ -240,6 +241,15 @@
     "saving": "Aan het opslaan…",
     "cancel": "Annuleren",
     "reimbursement": "Terugbetaling",
+    "multiPayer": "Meerdere betalers",
+    "multiPayerToggle": "Verdeel de betaling over meerdere deelnemers",
+    "paidByCard": {
+      "title": "Betaald door",
+      "description": "Selecteer wie deze uitgave heeft betaald en hoe de betaling verdeeld moet worden."
+    },
+    "PaidBySplitModeField": {
+      "label": "Betalerverdeelmodus"
+    },
     "conversionUnavailable": "Om een andere munteenheid in te stellen voor een uitgave en bedragen om te rekenen, kies een standaard munteenheid voor de groep.",
     "originalAmountField": {
       "label": "Om te rekenen bedrag"
@@ -372,6 +382,8 @@
     "noZeroShares": "Een deel mag niet 0 zijn.",
     "amountSum": "Het totaalbedrag moet gelijk zijn aan het uitgavebedrag.",
     "percentageSum": "Het totaalpercentage moet gelijk zijn aan 100%.",
+    "paidByAmountSum": "De som van de bedragen van de betalers moet gelijk zijn aan het uitgavebedrag.",
+    "paidByPercentageSum": "De som van de percentages van de betalers moet gelijk zijn aan 100.",
     "ratePositive": "De koers moet groter dan nul zijn."
   },
   "Categories": {

--- a/messages/pl-PL.json
+++ b/messages/pl-PL.json
@@ -43,6 +43,7 @@
   },
   "ExpenseCard": {
     "paidBy": "Opłacone przez <strong>{paidBy}</strong> dla <paidFor></paidFor>",
+    "paidByMultiple": "Zapłacone przez <paidByNames></paidByNames> za <paidFor></paidFor>",
     "receivedBy": "Otrzymane przez <strong>{paidBy}</strong> od <paidFor></paidFor>",
     "yourBalance": "Twjoje saldo:"
   },
@@ -214,7 +215,16 @@
     "save": "Zapisz",
     "saving": "Zapisywanie…",
     "cancel": "Anuluj",
-    "reimbursement": "Zwrot środków"
+    "reimbursement": "Zwrot środków",
+    "multiPayer": "Wielu płatników",
+    "multiPayerToggle": "Podziel płatność między wielu uczestników",
+    "paidByCard": {
+      "title": "Zapłacone przez",
+      "description": "Wybierz, kto zapłacił za ten wydatek i jak podzielić płatność."
+    },
+    "PaidBySplitModeField": {
+      "label": "Tryb podziału płatnika"
+    }
   },
   "ExpenseDocumentsInput": {
     "TooBigToast": {
@@ -325,7 +335,9 @@
     "paidForMin1": "Wydatek musi zostać opłacony za co najmniej jednego uczestnika.",
     "noZeroShares": "Wszystkie udziały muszą być większe niż 0.",
     "amountSum": "Suma udziałów musi być równa wydatkowi.",
-    "percentageSum": "Suma procentów musi być równa 100."
+    "percentageSum": "Suma procentów musi być równa 100.",
+    "paidByAmountSum": "Suma kwot płatników musi być równa kwocie wydatku.",
+    "paidByPercentageSum": "Suma procentów płatników musi wynosić 100."
   },
   "Categories": {
     "search": "Szukaj kategorii…",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -43,6 +43,7 @@
   },
   "ExpenseCard": {
     "paidBy": "Pago por <strong>{paidBy}</strong> para <paidFor></paidFor>",
+    "paidByMultiple": "Pago por <paidByNames></paidByNames> para <paidFor></paidFor>",
     "receivedBy": "Recebido por <strong>{paidBy}</strong> para <paidFor></paidFor>",
     "yourBalance": "Seu saldo:",
     "everyone": "Todos",
@@ -224,6 +225,15 @@
     "saving": "Salvando…",
     "cancel": "Cancelar",
     "reimbursement": "Reembolso",
+    "multiPayer": "Múltiplos pagadores",
+    "multiPayerToggle": "Dividir o pagamento entre múltiplos participantes",
+    "paidByCard": {
+      "title": "Pago por",
+      "description": "Selecione quem pagou esta despesa e como dividir o pagamento."
+    },
+    "PaidBySplitModeField": {
+      "label": "Modo de divisão do pagador"
+    },
     "conversionRateField": {
       "label": "Taxa de câmbio"
     },
@@ -342,7 +352,9 @@
     "paidForMin1": "A despesa deve ser paga para pelo menos um participante.",
     "noZeroShares": "Todas as partes devem ser maiores que 0.",
     "amountSum": "A soma dos valores deve ser igual ao valor da despesa.",
-    "percentageSum": "A soma das porcentagens deve ser igual a 100."
+    "percentageSum": "A soma das porcentagens deve ser igual a 100.",
+    "paidByAmountSum": "A soma dos valores dos pagadores deve ser igual ao valor da despesa.",
+    "paidByPercentageSum": "A soma das porcentagens dos pagadores deve ser igual a 100."
   },
   "Categories": {
     "search": "Pesquisar categoria...",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -43,6 +43,7 @@
   },
   "ExpenseCard": {
     "paidBy": "Pago por <strong>{paidBy}</strong> para <paidFor></paidFor>",
+    "paidByMultiple": "Pago por <paidByNames></paidByNames> para <paidFor></paidFor>",
     "everyone": "todos",
     "receivedBy": "Recebido por <strong>{paidBy}</strong> para <paidFor></paidFor>",
     "yourBalance": "O teu saldo:",
@@ -123,5 +124,20 @@
       },
       "save": "Gravar"
     }
+  },
+  "ExpenseForm": {
+    "multiPayer": "Múltiplos pagadores",
+    "multiPayerToggle": "Dividir o pagamento entre múltiplos participantes",
+    "paidByCard": {
+      "title": "Pago por",
+      "description": "Selecione quem pagou esta despesa e como dividir o pagamento."
+    },
+    "PaidBySplitModeField": {
+      "label": "Modo de divisão do pagador"
+    }
+  },
+  "SchemaErrors": {
+    "paidByAmountSum": "A soma dos montantes dos pagadores deve ser igual ao montante da despesa.",
+    "paidByPercentageSum": "A soma das percentagens dos pagadores deve ser igual a 100."
   }
 }

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -42,6 +42,7 @@
   },
   "ExpenseCard": {
     "paidBy": "Plătit de <strong>{paidBy}</strong> pentru <paidFor></paidFor>",
+    "paidByMultiple": "Plătit de <paidByNames></paidByNames> pentru <paidFor></paidFor>",
     "receivedBy": "Primit de <strong>{paidBy}</strong> pentru <paidFor></paidFor>",
     "yourBalance": "Soldul tău:"
   },
@@ -205,7 +206,16 @@
     "save": "Salvează",
     "saving": "Se salvează…",
     "cancel": "Anulează",
-    "reimbursement": "Rambursare"
+    "reimbursement": "Rambursare",
+    "multiPayer": "Mai mulți plătitori",
+    "multiPayerToggle": "Împarte plata între mai mulți participanți",
+    "paidByCard": {
+      "title": "Plătit de",
+      "description": "Selectează cine a plătit această cheltuială și cum să împarți plata."
+    },
+    "PaidBySplitModeField": {
+      "label": "Modul de împărțire a plătitorului"
+    }
   },
   "ExpenseDocumentsInput": {
     "TooBigToast": {
@@ -316,7 +326,9 @@
     "paidForMin1": "Cheltuiala trebuie plătită pentru cel puțin un membru.",
     "noZeroShares": "Toate părțile trebuie să fie mai mari de 0.",
     "amountSum": "Suma valorilor trebuie să fie egală cu suma cheltuielilor.",
-    "percentageSum": "Suma procentajelor trebuie să fie egală cu 100."
+    "percentageSum": "Suma procentajelor trebuie să fie egală cu 100.",
+    "paidByAmountSum": "Suma sumelor plătitorilor trebuie să fie egală cu suma cheltuielii.",
+    "paidByPercentageSum": "Suma procentelor plătitorilor trebuie să fie egală cu 100."
   },
   "Categories": {
     "search": "Căutați categorie…",

--- a/messages/ru-RU.json
+++ b/messages/ru-RU.json
@@ -43,6 +43,7 @@
   },
   "ExpenseCard": {
     "paidBy": "Потратил <strong>{paidBy}</strong> за <paidFor></paidFor>",
+    "paidByMultiple": "Оплачено <paidByNames></paidByNames> за <paidFor></paidFor>",
     "receivedBy": "Получил <strong>{paidBy}</strong> за <paidFor></paidFor>",
     "yourBalance": "Изменение баланса участника:"
   },
@@ -206,7 +207,16 @@
     "save": "Сохранить",
     "saving": "Сохранение…",
     "cancel": "Отмена",
-    "reimbursement": "Возмещение"
+    "reimbursement": "Возмещение",
+    "multiPayer": "Несколько плательщиков",
+    "multiPayerToggle": "Разделить платёж между несколькими участниками",
+    "paidByCard": {
+      "title": "Оплачено",
+      "description": "Выберите, кто оплатил этот расход и как разделить платёж."
+    },
+    "PaidBySplitModeField": {
+      "label": "Режим разделения плательщика"
+    }
   },
   "ExpenseDocumentsInput": {
     "TooBigToast": {
@@ -317,7 +327,9 @@
     "paidForMin1": "За этот расход должен заплатить как минимум один участник.",
     "noZeroShares": "Все доли должны быть больше 0.",
     "amountSum": "Сумма расхода должна быть равна сумме значений, распределенных между участниками.",
-    "percentageSum": "Сумма процентов должна быть равна 100."
+    "percentageSum": "Сумма процентов должна быть равна 100.",
+    "paidByAmountSum": "Сумма сумм плательщиков должна быть равна сумме расхода.",
+    "paidByPercentageSum": "Сумма процентов плательщиков должна быть равна 100."
   },
   "Categories": {
     "search": "Поиск категорий...",

--- a/messages/tr-TR.json
+++ b/messages/tr-TR.json
@@ -42,6 +42,7 @@
   },
   "ExpenseCard": {
     "paidBy": "<strong>{paidBy}</strong> tarafından ödendi, <paidFor></paidFor> için",
+    "paidByMultiple": "<paidByNames></paidByNames> tarafından <paidFor></paidFor> için ödendi",
     "receivedBy": "<strong>{paidBy}</strong> tarafından alındı, <paidFor></paidFor> için",
     "yourBalance": "Bakiyeniz:"
   },
@@ -205,7 +206,16 @@
     "save": "Kaydet",
     "saving": "Kaydediliyor…",
     "cancel": "İptal",
-    "reimbursement": "Geri ödeme"
+    "reimbursement": "Geri ödeme",
+    "multiPayer": "Birden fazla ödeyen",
+    "multiPayerToggle": "Ödemeyi birden fazla katılımcı arasında böl",
+    "paidByCard": {
+      "title": "Ödeyen",
+      "description": "Bu harcamayı kimin ödediğini ve ödemenin nasıl bölüneceğini seçin."
+    },
+    "PaidBySplitModeField": {
+      "label": "Ödeyen bölme modu"
+    }
   },
   "ExpenseDocumentsInput": {
     "TooBigToast": {
@@ -316,7 +326,9 @@
     "paidForMin1": "Masraf en az bir katılımcı için ödenmiş olmalıdır.",
     "noZeroShares": "Tüm paylar 0'dan büyük olmalıdır.",
     "amountSum": "Tutarların toplamı masraf tutarına eşit olmalıdır.",
-    "percentageSum": "Yüzdelerin toplamı 100 olmalıdır."
+    "percentageSum": "Yüzdelerin toplamı 100 olmalıdır.",
+    "paidByAmountSum": "Ödeyenlerin tutarlarının toplamı harcama tutarına eşit olmalıdır.",
+    "paidByPercentageSum": "Ödeyenlerin yüzdelerinin toplamı 100'e eşit olmalıdır."
   },
   "Categories": {
     "search": "Kategori ara...",

--- a/messages/uk-UA.json
+++ b/messages/uk-UA.json
@@ -42,6 +42,7 @@
   },
   "ExpenseCard": {
     "paidBy": "Сплачено <strong>{paidBy}</strong> за <paidFor></paidFor>",
+    "paidByMultiple": "Сплачено <paidByNames></paidByNames> за <paidFor></paidFor>",
     "receivedBy": "Отримано <strong>{paidBy}</strong> за <paidFor></paidFor>",
     "yourBalance": "Ваш баланс:"
   },
@@ -205,7 +206,16 @@
     "save": "Зберегти",
     "saving": "Збереження..",
     "cancel": "Скасувати",
-    "reimbursement": "Відшкодування"
+    "reimbursement": "Відшкодування",
+    "multiPayer": "Кілька платників",
+    "multiPayerToggle": "Розділити платіж між кількома учасниками",
+    "paidByCard": {
+      "title": "Сплачено",
+      "description": "Виберіть, хто оплатив цю витрату і як розділити платіж."
+    },
+    "PaidBySplitModeField": {
+      "label": "Режим розділення платника"
+    }
   },
   "ExpenseDocumentsInput": {
     "TooBigToast": {
@@ -316,7 +326,9 @@
     "paidForMin1": "Витрата повинна бути сплачена принаймні для одного учасника",
     "noZeroShares": "Усі частки повинні бути більшими за 0",
     "amountSum": "Сума повинна відповідати витраті",
-    "percentageSum": "Сума відсотків повинна дорівнювати 100"
+    "percentageSum": "Сума відсотків повинна дорівнювати 100",
+    "paidByAmountSum": "Сума сум платників повинна дорівнювати сумі витрати.",
+    "paidByPercentageSum": "Сума відсотків платників повинна дорівнювати 100."
   },
   "Categories": {
     "search": "Шукати категорію..",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -43,6 +43,7 @@
   },
   "ExpenseCard": {
     "paidBy": "<strong>{paidBy}</strong> 为 <paidFor></paidFor> 支付。",
+    "paidByMultiple": "由 <paidByNames></paidByNames> 为 <paidFor></paidFor> 支付",
     "receivedBy": "<strong>{paidBy}</strong> 为 <paidFor></paidFor> 接收。",
     "yourBalance": "你的余额：",
     "everyone": "所有人",
@@ -229,6 +230,15 @@
     "saving": "保存中……",
     "cancel": "取消",
     "reimbursement": "报销",
+    "multiPayer": "多个付款人",
+    "multiPayerToggle": "将付款分摊给多个参与者",
+    "paidByCard": {
+      "title": "付款人",
+      "description": "选择谁支付了这笔费用以及如何分摊付款。"
+    },
+    "PaidBySplitModeField": {
+      "label": "付款人分摊模式"
+    },
     "originalAmountField": {
       "label": "需要转换的金额"
     },
@@ -356,7 +366,9 @@
     "noZeroShares": "所有份额必须大于0。",
     "amountSum": "金额之和必须等于消费的金额。",
     "percentageSum": "百分比之和必须等于100。",
-    "ratePositive": "汇率必须为正数（大于0）。"
+    "ratePositive": "汇率必须为正数（大于0）。",
+    "paidByAmountSum": "付款人金额之和必须等于费用金额。",
+    "paidByPercentageSum": "付款人百分比之和必须等于100。"
   },
   "Categories": {
     "search": "搜寻类别……",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -42,6 +42,7 @@
   },
   "ExpenseCard": {
     "paidBy": "由 <strong>{paidBy}</strong> 支付 <paidFor></paidFor>。",
+    "paidByMultiple": "由 <paidByNames></paidByNames> 為 <paidFor></paidFor> 支付",
     "receivedBy": "由 <strong>{paidBy}</strong> 收取 <paidFor></paidFor>。",
     "yourBalance": "你的餘額："
   },
@@ -205,7 +206,16 @@
     "save": "儲存",
     "saving": "儲存中……",
     "cancel": "取消",
-    "reimbursement": "報銷"
+    "reimbursement": "報銷",
+    "multiPayer": "多位付款人",
+    "multiPayerToggle": "將付款分攤給多位參與者",
+    "paidByCard": {
+      "title": "付款人",
+      "description": "選擇誰支付了這筆費用以及如何分攤付款。"
+    },
+    "PaidBySplitModeField": {
+      "label": "付款人分攤模式"
+    }
   },
   "ExpenseDocumentsInput": {
     "TooBigToast": {
@@ -316,7 +326,9 @@
     "paidForMin1": "這筆消費必須包含至少一個成員。",
     "noZeroShares": "份額需大於 0。",
     "amountSum": "金額總計必須等於消費金額。",
-    "percentageSum": "百分比加總必須等於 100。"
+    "percentageSum": "百分比加總必須等於 100。",
+    "paidByAmountSum": "付款人金額之和必須等於費用金額。",
+    "paidByPercentageSum": "付款人百分比之和必須等於100。"
   },
   "Categories": {
     "search": "搜尋類別……",

--- a/prisma/migrations/20260310000000_add_multi_payer_support/migration.sql
+++ b/prisma/migrations/20260310000000_add_multi_payer_support/migration.sql
@@ -1,0 +1,26 @@
+-- CreateTable
+CREATE TABLE "ExpensePaidBy" (
+    "expenseId" TEXT NOT NULL,
+    "participantId" TEXT NOT NULL,
+    "shares" INTEGER NOT NULL DEFAULT 1,
+
+    CONSTRAINT "ExpensePaidBy_pkey" PRIMARY KEY ("expenseId","participantId")
+);
+
+-- AddColumn
+ALTER TABLE "Expense" ADD COLUMN "paidBySplitMode" "SplitMode" NOT NULL DEFAULT 'BY_AMOUNT';
+
+-- AddForeignKey
+ALTER TABLE "ExpensePaidBy" ADD CONSTRAINT "ExpensePaidBy_expenseId_fkey" FOREIGN KEY ("expenseId") REFERENCES "Expense"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ExpensePaidBy" ADD CONSTRAINT "ExpensePaidBy_participantId_fkey" FOREIGN KEY ("participantId") REFERENCES "Participant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- CreateIndex
+CREATE INDEX "ExpensePaidBy_participantId_idx" ON "ExpensePaidBy"("participantId");
+
+-- Migrate existing data: each expense's paidById becomes a single ExpensePaidBy row
+-- with shares = amount (matching BY_AMOUNT split mode)
+-- Use GREATEST to guard against zero-amount expenses causing division-by-zero
+INSERT INTO "ExpensePaidBy" ("expenseId", "participantId", "shares")
+SELECT "id", "paidById", GREATEST("amount", 1) FROM "Expense";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,12 +24,13 @@ model Group {
 }
 
 model Participant {
-  id              String           @id
-  name            String
-  group           Group            @relation(fields: [groupId], references: [id], onDelete: Cascade)
-  groupId         String
-  expensesPaidBy  Expense[]
-  expensesPaidFor ExpensePaidFor[]
+  id                 String            @id
+  name               String
+  group              Group             @relation(fields: [groupId], references: [id], onDelete: Cascade)
+  groupId            String
+  expensesPaidBy     Expense[]
+  expensesPaidFor    ExpensePaidFor[]
+  expensesPaidByList ExpensePaidBy[]
 }
 
 model Category {
@@ -53,6 +54,8 @@ model Expense {
   paidBy           Participant       @relation(fields: [paidById], references: [id], onDelete: Cascade)
   paidById         String
   paidFor          ExpensePaidFor[]
+  paidByList       ExpensePaidBy[]
+  paidBySplitMode  SplitMode         @default(BY_AMOUNT)
   groupId          String
   isReimbursement  Boolean           @default(false)
   splitMode        SplitMode         @default(EVENLY)
@@ -112,6 +115,17 @@ model ExpensePaidFor {
   shares        Int         @default(1)
 
   @@id([expenseId, participantId])
+}
+
+model ExpensePaidBy {
+  expense       Expense     @relation(fields: [expenseId], references: [id], onDelete: Cascade)
+  participant   Participant @relation(fields: [participantId], references: [id], onDelete: Cascade)
+  expenseId     String
+  participantId String
+  shares        Int         @default(1)
+
+  @@id([expenseId, participantId])
+  @@index([participantId])
 }
 
 model Activity {

--- a/src/app/groups/[groupId]/expenses/expense-card.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-card.tsx
@@ -22,7 +22,6 @@ function Participants({
   participantCount: number
 }) {
   const t = useTranslations('ExpenseCard')
-  const key = expense.amount > 0 ? 'paidBy' : 'receivedBy'
   const paidFor =
     expense.paidFor.length == participantCount && participantCount >= 4 ? (
       <strong>{t('everyone')}</strong>
@@ -35,6 +34,27 @@ function Participants({
       ))
     )
 
+  const paidByList = (expense as any).paidByList as
+    | { participant: { id: string; name: string }; shares: number }[]
+    | undefined
+  const isMultiPayer = paidByList && paidByList.length > 1
+
+  if (isMultiPayer) {
+    const paidByNames = paidByList.map((pb, index) => (
+      <Fragment key={index}>
+        {index !== 0 && <>, </>}
+        <strong>{pb.participant.name}</strong>
+      </Fragment>
+    ))
+    const participants = t.rich('paidByMultiple', {
+      strong: (chunks) => <strong>{chunks}</strong>,
+      paidByNames: () => <>{paidByNames}</>,
+      paidFor: () => paidFor,
+    })
+    return <>{participants}</>
+  }
+
+  const key = expense.amount > 0 ? 'paidBy' : 'receivedBy'
   const participants = t.rich(key, {
     strong: (chunks) => <strong>{chunks}</strong>,
     paidBy: expense.paidBy.name,

--- a/src/app/groups/[groupId]/expenses/expense-form.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-form.tsx
@@ -202,6 +202,15 @@ export function ExpenseForm({
               : (shares / 100).toString()) as any, // Convert to string to ensure consistent handling
           })),
           splitMode: expense.splitMode,
+          isMultiPayer: ((expense as any).paidByList?.length ?? 0) > 1,
+          paidByList: ((expense as any).paidByList ?? []).map((p: any) => ({
+            participant: p.participantId,
+            shares:
+              (expense as any).paidBySplitMode === 'BY_AMOUNT'
+                ? amountAsDecimal(p.shares, groupCurrency)
+                : p.shares / 100,
+          })),
+          paidBySplitMode: (expense as any).paidBySplitMode ?? 'BY_AMOUNT',
           saveDefaultSplittingOptions: false,
           isReimbursement: expense.isReimbursement,
           documents: expense.documents,
@@ -231,6 +240,9 @@ export function ExpenseForm({
           ],
           isReimbursement: true,
           splitMode: defaultSplittingOptions.splitMode,
+          isMultiPayer: false,
+          paidByList: [],
+          paidBySplitMode: 'BY_AMOUNT' as const,
           saveDefaultSplittingOptions: false,
           documents: [],
           notes: '',
@@ -253,6 +265,9 @@ export function ExpenseForm({
           paidBy: getSelectedPayer(),
           isReimbursement: false,
           splitMode: defaultSplittingOptions.splitMode,
+          isMultiPayer: false,
+          paidByList: [],
+          paidBySplitMode: 'BY_AMOUNT' as const,
           saveDefaultSplittingOptions: false,
           documents: searchParams.get('imageUrl')
             ? [
@@ -283,6 +298,15 @@ export function ExpenseForm({
           ? amountAsMinorUnits(shares, groupCurrency)
           : shares,
     }))
+    if (values.isMultiPayer && values.paidByList.length > 0) {
+      values.paidByList = values.paidByList.map(({ participant, shares }) => ({
+        participant,
+        shares:
+          values.paidBySplitMode === 'BY_AMOUNT'
+            ? amountAsMinorUnits(shares, groupCurrency)
+            : shares,
+      }))
+    }
 
     // Currency should be blank if same as group currency
     if (!conversionRequired) {
@@ -732,26 +756,72 @@ export function ExpenseForm({
               render={({ field }) => (
                 <FormItem className="sm:order-5">
                   <FormLabel>{t(`${sExpense}.paidByField.label`)}</FormLabel>
-                  <Select
-                    onValueChange={field.onChange}
-                    defaultValue={getSelectedPayer(field)}
-                  >
-                    <SelectTrigger>
-                      <SelectValue
-                        placeholder={t(`${sExpense}.paidByField.placeholder`)}
-                      />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {group.participants.map(({ id, name }) => (
-                        <SelectItem key={id} value={id}>
-                          {name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <FormDescription>
-                    {t(`${sExpense}.paidByField.description`)}
-                  </FormDescription>
+                  {!form.watch('isMultiPayer') && (
+                    <>
+                      <Select
+                        onValueChange={field.onChange}
+                        defaultValue={getSelectedPayer(field)}
+                      >
+                        <SelectTrigger>
+                          <SelectValue
+                            placeholder={t(
+                              `${sExpense}.paidByField.placeholder`,
+                            )}
+                          />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {group.participants.map(({ id, name }) => (
+                            <SelectItem key={id} value={id}>
+                              {name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormDescription>
+                        {t(`${sExpense}.paidByField.description`)}
+                      </FormDescription>
+                    </>
+                  )}
+                  {!form.watch('isReimbursement') && (
+                    <FormField
+                      control={form.control}
+                      name="isMultiPayer"
+                      render={({ field: multiPayerField }) => (
+                        <FormItem className="flex flex-row gap-2 items-center space-y-0 pt-2">
+                          <FormControl>
+                            <Checkbox
+                              checked={multiPayerField.value}
+                              onCheckedChange={(checked) => {
+                                multiPayerField.onChange(checked)
+                                if (checked) {
+                                  // Initialize paidByList with current payer
+                                  const currentPayer = form.getValues('paidBy')
+                                  if (
+                                    currentPayer &&
+                                    form.getValues('paidByList').length === 0
+                                  ) {
+                                    form.setValue('paidByList', [
+                                      {
+                                        participant: currentPayer,
+                                        shares: 1,
+                                      },
+                                    ])
+                                    form.setValue(
+                                      'paidBySplitMode',
+                                      'BY_AMOUNT',
+                                    )
+                                  }
+                                }
+                              }}
+                            />
+                          </FormControl>
+                          <div>
+                            <FormLabel>{t('multiPayerToggle')}</FormLabel>
+                          </div>
+                        </FormItem>
+                      )}
+                    />
+                  )}
                   <FormMessage />
                 </FormItem>
               )}
@@ -807,6 +877,247 @@ export function ExpenseForm({
             />
           </CardContent>
         </Card>
+
+        {form.watch('isMultiPayer') && (
+          <Card className="mt-4">
+            <CardHeader>
+              <CardTitle className="flex justify-between">
+                <span>{t('paidByCard.title')}</span>
+                <Button
+                  variant="link"
+                  type="button"
+                  className="-my-2 -mx-4"
+                  onClick={() => {
+                    const paidByList = form.getValues().paidByList
+                    const allSelected =
+                      paidByList.length === group.participants.length
+                    const newPaidByList = allSelected
+                      ? []
+                      : group.participants.map((p) => ({
+                          participant: p.id,
+                          shares:
+                            paidByList.find((pb) => pb.participant === p.id)
+                              ?.shares ?? 1,
+                        }))
+                    form.setValue('paidByList', newPaidByList, {
+                      shouldDirty: true,
+                      shouldTouch: true,
+                      shouldValidate: true,
+                    })
+                  }}
+                >
+                  {form.getValues().paidByList.length ===
+                  group.participants.length ? (
+                    <>{t('selectNone')}</>
+                  ) : (
+                    <>{t('selectAll')}</>
+                  )}
+                </Button>
+              </CardTitle>
+              <CardDescription>{t('paidByCard.description')}</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <FormField
+                control={form.control}
+                name="paidByList"
+                render={() => (
+                  <FormItem className="space-y-0">
+                    {group.participants.map(({ id, name }) => (
+                      <FormField
+                        key={id}
+                        control={form.control}
+                        name="paidByList"
+                        render={({ field }) => {
+                          return (
+                            <div className="flex flex-wrap gap-y-4 items-center border-t last-of-type:border-b last-of-type:!mb-4 -mx-6 px-6 py-3">
+                              <FormItem className="flex-1 flex flex-row items-start space-x-3 space-y-0">
+                                <FormControl>
+                                  <Checkbox
+                                    checked={field.value?.some(
+                                      ({ participant }) => participant === id,
+                                    )}
+                                    onCheckedChange={(checked) => {
+                                      const options = {
+                                        shouldDirty: true,
+                                        shouldTouch: true,
+                                        shouldValidate: true,
+                                      }
+                                      checked
+                                        ? form.setValue(
+                                            'paidByList',
+                                            [
+                                              ...field.value,
+                                              {
+                                                participant: id,
+                                                shares: 1,
+                                              },
+                                            ],
+                                            options,
+                                          )
+                                        : form.setValue(
+                                            'paidByList',
+                                            field.value?.filter(
+                                              (value) =>
+                                                value.participant !== id,
+                                            ),
+                                            options,
+                                          )
+                                    }}
+                                  />
+                                </FormControl>
+                                <FormLabel className="text-sm font-normal flex-1">
+                                  {name}
+                                </FormLabel>
+                              </FormItem>
+                              <div className="flex">
+                                {form.getValues().paidBySplitMode !==
+                                  'EVENLY' && (
+                                  <div>
+                                    <div className="flex gap-1 items-center">
+                                      {form.getValues().paidBySplitMode ===
+                                        'BY_AMOUNT' && (
+                                        <span
+                                          className={cn('text-sm', {
+                                            'text-muted': !field.value?.some(
+                                              ({ participant }) =>
+                                                participant === id,
+                                            ),
+                                          })}
+                                        >
+                                          {group.currency}
+                                        </span>
+                                      )}
+                                      <Input
+                                        key={String(
+                                          !field.value?.some(
+                                            ({ participant }) =>
+                                              participant === id,
+                                          ),
+                                        )}
+                                        className="text-base w-[80px] -my-2"
+                                        type="text"
+                                        disabled={
+                                          !field.value?.some(
+                                            ({ participant }) =>
+                                              participant === id,
+                                          )
+                                        }
+                                        value={
+                                          field.value?.find(
+                                            ({ participant }) =>
+                                              participant === id,
+                                          )?.shares
+                                        }
+                                        onChange={(event) => {
+                                          field.onChange(
+                                            field.value.map((p) =>
+                                              p.participant === id
+                                                ? {
+                                                    participant: id,
+                                                    shares:
+                                                      enforceCurrencyPattern(
+                                                        event.target.value,
+                                                      ),
+                                                  }
+                                                : p,
+                                            ),
+                                          )
+                                        }}
+                                        inputMode={
+                                          form.getValues().paidBySplitMode ===
+                                          'BY_AMOUNT'
+                                            ? 'decimal'
+                                            : 'numeric'
+                                        }
+                                        step={
+                                          form.getValues().paidBySplitMode ===
+                                          'BY_AMOUNT'
+                                            ? 10 **
+                                              -groupCurrency.decimal_digits
+                                            : 1
+                                        }
+                                      />
+                                      {['BY_SHARES', 'BY_PERCENTAGE'].includes(
+                                        form.getValues().paidBySplitMode,
+                                      ) && (
+                                        <span
+                                          className={cn('text-sm', {
+                                            'text-muted': !field.value?.some(
+                                              ({ participant }) =>
+                                                participant === id,
+                                            ),
+                                          })}
+                                        >
+                                          {match(
+                                            form.getValues().paidBySplitMode,
+                                          )
+                                            .with('BY_SHARES', () => (
+                                              <>{t('shares')}</>
+                                            ))
+                                            .with('BY_PERCENTAGE', () => <>%</>)
+                                            .otherwise(() => (
+                                              <></>
+                                            ))}
+                                        </span>
+                                      )}
+                                    </div>
+                                  </div>
+                                )}
+                              </div>
+                            </div>
+                          )
+                        }}
+                      />
+                    ))}
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <div className="mt-4">
+                <FormField
+                  control={form.control}
+                  name="paidBySplitMode"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>{t('PaidBySplitModeField.label')}</FormLabel>
+                      <FormControl>
+                        <Select
+                          onValueChange={(value) => {
+                            form.setValue('paidBySplitMode', value as any, {
+                              shouldDirty: true,
+                              shouldTouch: true,
+                              shouldValidate: true,
+                            })
+                          }}
+                          defaultValue={field.value}
+                        >
+                          <SelectTrigger>
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="EVENLY">
+                              {t('SplitModeField.evenly')}
+                            </SelectItem>
+                            <SelectItem value="BY_SHARES">
+                              {t('SplitModeField.byShares')}
+                            </SelectItem>
+                            <SelectItem value="BY_PERCENTAGE">
+                              {t('SplitModeField.byPercentage')}
+                            </SelectItem>
+                            <SelectItem value="BY_AMOUNT">
+                              {t('SplitModeField.byAmount')}
+                            </SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </FormControl>
+                    </FormItem>
+                  )}
+                />
+              </div>
+            </CardContent>
+          </Card>
+        )}
 
         <Card className="mt-4">
           <CardHeader>

--- a/src/app/groups/[groupId]/expenses/export/csv/route.ts
+++ b/src/app/groups/[groupId]/expenses/export/csv/route.ts
@@ -45,6 +45,8 @@ export async function GET(
           conversionRate: true,
           paidById: true,
           paidFor: { select: { participantId: true, shares: true } },
+          paidByList: { select: { participantId: true, shares: true } },
+          paidBySplitMode: true,
           isReimbursement: true,
           splitMode: true,
         },
@@ -122,6 +124,7 @@ export async function GET(
     splitMode: splitModeLabel[expense.splitMode],
     ...Object.fromEntries(
       group.participants.map((participant) => {
+        // Calculate how much this participant owes (paidFor share)
         const { totalShares, participantShare } = expense.paidFor.reduce(
           (acc, { participantId, shares }) => {
             acc.totalShares += shares
@@ -133,16 +136,41 @@ export async function GET(
           { totalShares: 0, participantShare: 0 },
         )
 
-        const isPaidByParticipant = expense.paidById === participant.id
-        const participantAmountShare = +formatAmountAsDecimal(
+        // Calculate how much this participant paid (paidByList share)
+        const paidByList = (expense as any).paidByList as
+          | { participantId: string; shares: number }[]
+          | undefined
+        const paidBySplitMode =
+          ((expense as any).paidBySplitMode as string) ?? 'BY_AMOUNT'
+        let paidAmount = 0
+        if (paidByList && paidByList.length > 0) {
+          const paidByEntry = paidByList.find(
+            (p) => p.participantId === participant.id,
+          )
+          if (paidByEntry) {
+            const totalPaidByShares = paidByList.reduce(
+              (sum, p) => sum + p.shares,
+              0,
+            )
+            if (paidBySplitMode === 'EVENLY') {
+              paidAmount = expense.amount / paidByList.length
+            } else {
+              paidAmount =
+                (expense.amount * paidByEntry.shares) / totalPaidByShares
+            }
+          }
+        } else {
+          // Legacy: single payer
+          paidAmount = expense.paidById === participant.id ? expense.amount : 0
+        }
+
+        const owedAmount = +formatAmountAsDecimal(
           (expense.amount / totalShares) * participantShare,
           currency,
         )
+        const paidFormatted = +formatAmountAsDecimal(paidAmount, currency)
 
-        return [
-          participant.name,
-          participantAmountShare * (isPaidByParticipant ? 1 : -1),
-        ]
+        return [participant.name, paidFormatted - owedAmount]
       }),
     ),
   }))

--- a/src/app/groups/[groupId]/expenses/export/json/route.ts
+++ b/src/app/groups/[groupId]/expenses/export/json/route.ts
@@ -26,6 +26,8 @@ export async function GET(
           conversionRate: true,
           paidById: true,
           paidFor: { select: { participantId: true, shares: true } },
+          paidByList: { select: { participantId: true, shares: true } },
+          paidBySplitMode: true,
           isReimbursement: true,
           splitMode: true,
           recurrenceRule: true,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -44,6 +44,7 @@ export async function createExpense(
   for (const participant of [
     expenseFormValues.paidBy,
     ...expenseFormValues.paidFor.map((p) => p.participant),
+    ...expenseFormValues.paidByList.map((p) => p.participant),
   ]) {
     if (!group.participants.some((p) => p.id === participant))
       throw new Error(`Invalid participant ID: ${participant}`)
@@ -64,6 +65,20 @@ export async function createExpense(
     groupId,
   )
 
+  // Build paidByList data
+  const paidByListData =
+    expenseFormValues.isMultiPayer && expenseFormValues.paidByList.length > 0
+      ? expenseFormValues.paidByList.map((p) => ({
+          participantId: p.participant,
+          shares: p.shares,
+        }))
+      : [
+          {
+            participantId: expenseFormValues.paidBy,
+            shares: expenseFormValues.amount,
+          },
+        ]
+
   return prisma.expense.create({
     data: {
       id: expenseId,
@@ -77,6 +92,11 @@ export async function createExpense(
       title: expenseFormValues.title,
       paidById: expenseFormValues.paidBy,
       splitMode: expenseFormValues.splitMode,
+      paidBySplitMode:
+        expenseFormValues.isMultiPayer &&
+        expenseFormValues.paidByList.length > 0
+          ? expenseFormValues.paidBySplitMode
+          : 'BY_AMOUNT',
       recurrenceRule: expenseFormValues.recurrenceRule,
       recurringExpenseLink: {
         ...(isCreateRecurrence
@@ -91,6 +111,11 @@ export async function createExpense(
             participantId: paidFor.participant,
             shares: paidFor.shares,
           })),
+        },
+      },
+      paidByList: {
+        createMany: {
+          data: paidByListData,
         },
       },
       isReimbursement: expenseFormValues.isReimbursement,
@@ -134,6 +159,7 @@ export async function getGroupExpensesParticipants(groupId: string) {
       expenses.flatMap((e) => [
         e.paidBy.id,
         ...e.paidFor.map((pf) => pf.participant.id),
+        ...e.paidByList.map((pb) => pb.participant.id),
       ]),
     ),
   )
@@ -166,6 +192,7 @@ export async function updateExpense(
   for (const participant of [
     expenseFormValues.paidBy,
     ...expenseFormValues.paidFor.map((p) => p.participant),
+    ...expenseFormValues.paidByList.map((p) => p.participant),
   ]) {
     if (!group.participants.some((p) => p.id === participant))
       throw new Error(`Invalid participant ID: ${participant}`)
@@ -216,7 +243,55 @@ export async function updateExpense(
       categoryId: expenseFormValues.category,
       paidById: expenseFormValues.paidBy,
       splitMode: expenseFormValues.splitMode,
+      paidBySplitMode:
+        expenseFormValues.isMultiPayer &&
+        expenseFormValues.paidByList.length > 0
+          ? expenseFormValues.paidBySplitMode
+          : 'BY_AMOUNT',
       recurrenceRule: expenseFormValues.recurrenceRule,
+      paidByList: (() => {
+        const newPaidByList =
+          expenseFormValues.isMultiPayer &&
+          expenseFormValues.paidByList.length > 0
+            ? expenseFormValues.paidByList.map((p) => ({
+                participantId: p.participant,
+                shares: p.shares,
+              }))
+            : [
+                {
+                  participantId: expenseFormValues.paidBy,
+                  shares: expenseFormValues.amount,
+                },
+              ]
+        const existingPaidByList = existingExpense.paidByList ?? []
+        return {
+          create: newPaidByList.filter(
+            (p) =>
+              !existingPaidByList.some(
+                (ep: any) => ep.participantId === p.participantId,
+              ),
+          ),
+          update: newPaidByList
+            .filter((p) =>
+              existingPaidByList.some(
+                (ep: any) => ep.participantId === p.participantId,
+              ),
+            )
+            .map((p) => ({
+              where: {
+                expenseId_participantId: {
+                  expenseId,
+                  participantId: p.participantId,
+                },
+              },
+              data: { shares: p.shares },
+            })),
+          deleteMany: existingPaidByList.filter(
+            (ep: any) =>
+              !newPaidByList.some((p) => p.participantId === ep.participantId),
+          ),
+        }
+      })(),
       paidFor: {
         create: expenseFormValues.paidFor
           .filter(
@@ -358,6 +433,13 @@ export async function getGroupExpenses(
           shares: true,
         },
       },
+      paidByList: {
+        select: {
+          participant: { select: { id: true, name: true } },
+          shares: true,
+        },
+      },
+      paidBySplitMode: true,
       splitMode: true,
       recurrenceRule: true,
       title: true,
@@ -385,6 +467,7 @@ export async function getExpense(groupId: string, expenseId: string) {
     include: {
       paidBy: true,
       paidFor: true,
+      paidByList: { include: { participant: true } },
       category: true,
       documents: true,
       recurringExpenseLink: true,
@@ -463,6 +546,7 @@ async function createRecurringExpenses() {
           include: {
             paidBy: true,
             paidFor: true,
+            paidByList: true,
             category: true,
             documents: true,
           },
@@ -489,6 +573,7 @@ async function createRecurringExpenses() {
         category,
         paidBy,
         paidFor,
+        paidByList,
         documents,
         ...destructeredCurrentExpenseRecord
       } = currentExpenseRecord
@@ -508,6 +593,16 @@ async function createRecurringExpenses() {
                     participantId: paidFor.participantId,
                     shares: paidFor.shares,
                   })),
+                },
+              },
+              paidByList: {
+                createMany: {
+                  data: currentExpenseRecord.paidByList.map(
+                    (paidByEntry: any) => ({
+                      participantId: paidByEntry.participantId,
+                      shares: paidByEntry.shares,
+                    }),
+                  ),
                 },
               },
               documents: {
@@ -530,6 +625,7 @@ async function createRecurringExpenses() {
             // Ensure that the same information is available on the returned record that was created
             include: {
               paidFor: true,
+              paidByList: true,
               documents: true,
               category: true,
               paidBy: true,

--- a/src/lib/balances.test.ts
+++ b/src/lib/balances.test.ts
@@ -3,7 +3,7 @@ import {
   getPublicBalances,
   getSuggestedReimbursements,
 } from './balances'
-import { makeExpense, alice, bob, charlie, dave } from './test-helpers'
+import { alice, bob, charlie, dave, makeExpense } from './test-helpers'
 
 describe('getBalances', () => {
   it('should return empty object for empty expenses', () => {

--- a/src/lib/balances.test.ts
+++ b/src/lib/balances.test.ts
@@ -1,0 +1,569 @@
+import {
+  getBalances,
+  getPublicBalances,
+  getSuggestedReimbursements,
+} from './balances'
+import { makeExpense, alice, bob, charlie, dave } from './test-helpers'
+
+describe('getBalances', () => {
+  it('should return empty object for empty expenses', () => {
+    expect(getBalances([])).toEqual({})
+  })
+
+  it('should handle single payer baseline (via paidByList with one entry)', () => {
+    const expenses = [
+      makeExpense({
+        amount: 3000,
+        paidBy: alice,
+        paidFor: [
+          { participant: alice, shares: 1 },
+          { participant: bob, shares: 1 },
+        ],
+        splitMode: 'EVENLY',
+      }),
+    ]
+
+    const balances = getBalances(expenses)
+    expect(balances[alice.id].paid).toBe(3000)
+    expect(balances[alice.id].paidFor).toBe(1500)
+    expect(balances[alice.id].total).toBe(1500)
+    expect(balances[bob.id].paid).toBe(0)
+    expect(balances[bob.id].paidFor).toBe(1500)
+    expect(balances[bob.id].total).toBe(-1500)
+  })
+
+  it('should handle legacy expense without paidByList (fallback path)', () => {
+    const expense = {
+      id: 'legacy-1',
+      amount: 2000,
+      paidBy: alice,
+      paidFor: [
+        { participant: alice, shares: 1 },
+        { participant: bob, shares: 1 },
+      ],
+      splitMode: 'EVENLY',
+      paidByList: [], // empty list triggers legacy fallback
+      paidBySplitMode: 'BY_AMOUNT',
+      isReimbursement: false,
+      title: 'Legacy',
+      expenseDate: new Date(),
+      createdAt: new Date(),
+      category: null,
+      recurrenceRule: 'NONE',
+      _count: { documents: 0 },
+    } as any
+
+    const balances = getBalances([expense])
+    expect(balances[alice.id].paid).toBe(2000)
+    expect(balances[alice.id].paidFor).toBe(1000)
+    expect(balances[bob.id].paid).toBe(0)
+    expect(balances[bob.id].paidFor).toBe(1000)
+  })
+
+  it('should handle explicit single-entry paidByList', () => {
+    const expenses = [
+      makeExpense({
+        amount: 5000,
+        paidBy: alice,
+        paidFor: [
+          { participant: alice, shares: 2500 },
+          { participant: bob, shares: 2500 },
+        ],
+        splitMode: 'BY_AMOUNT',
+        paidByList: [{ participant: alice, shares: 5000 }],
+        paidBySplitMode: 'BY_AMOUNT',
+      }),
+    ]
+
+    const balances = getBalances(expenses)
+    expect(balances[alice.id].paid).toBe(5000)
+    expect(balances[alice.id].paidFor).toBe(2500)
+    expect(balances[alice.id].total).toBe(2500)
+  })
+
+  it('should handle multi-payer BY_AMOUNT: Alice pays $20, Bob pays $10', () => {
+    const expenses = [
+      makeExpense({
+        amount: 3000,
+        paidBy: alice,
+        paidFor: [
+          { participant: alice, shares: 1500 },
+          { participant: bob, shares: 1500 },
+        ],
+        splitMode: 'BY_AMOUNT',
+        paidByList: [
+          { participant: alice, shares: 2000 },
+          { participant: bob, shares: 1000 },
+        ],
+        paidBySplitMode: 'BY_AMOUNT',
+      }),
+    ]
+
+    const balances = getBalances(expenses)
+    expect(balances[alice.id].paid).toBe(2000)
+    expect(balances[alice.id].paidFor).toBe(1500)
+    expect(balances[alice.id].total).toBe(500)
+    expect(balances[bob.id].paid).toBe(1000)
+    expect(balances[bob.id].paidFor).toBe(1500)
+    expect(balances[bob.id].total).toBe(-500)
+  })
+
+  it('should handle multi-payer EVENLY: 2 payers split $30 equally', () => {
+    const expenses = [
+      makeExpense({
+        amount: 3000,
+        paidBy: alice,
+        paidFor: [
+          { participant: alice, shares: 1000 },
+          { participant: bob, shares: 1000 },
+          { participant: charlie, shares: 1000 },
+        ],
+        splitMode: 'BY_AMOUNT',
+        paidByList: [
+          { participant: alice, shares: 1 },
+          { participant: bob, shares: 1 },
+        ],
+        paidBySplitMode: 'EVENLY',
+      }),
+    ]
+
+    const balances = getBalances(expenses)
+    expect(balances[alice.id].paid).toBe(1500)
+    expect(balances[alice.id].paidFor).toBe(1000)
+    expect(balances[alice.id].total).toBe(500)
+    expect(balances[bob.id].paid).toBe(1500)
+    expect(balances[bob.id].paidFor).toBe(1000)
+    expect(balances[bob.id].total).toBe(500)
+    expect(balances[charlie.id].paid).toBe(0)
+    expect(balances[charlie.id].paidFor).toBe(1000)
+    expect(balances[charlie.id].total).toBe(-1000)
+  })
+
+  it('should handle multi-payer BY_PERCENTAGE: 70%/30% split', () => {
+    const expenses = [
+      makeExpense({
+        amount: 10000,
+        paidBy: alice,
+        paidFor: [
+          { participant: alice, shares: 5000 },
+          { participant: bob, shares: 5000 },
+        ],
+        splitMode: 'BY_AMOUNT',
+        paidByList: [
+          { participant: alice, shares: 7000 },
+          { participant: bob, shares: 3000 },
+        ],
+        paidBySplitMode: 'BY_PERCENTAGE',
+      }),
+    ]
+
+    const balances = getBalances(expenses)
+    expect(balances[alice.id].paid).toBe(7000)
+    expect(balances[alice.id].total).toBe(2000)
+    expect(balances[bob.id].paid).toBe(3000)
+    expect(balances[bob.id].total).toBe(-2000)
+  })
+
+  it('should handle multi-payer BY_SHARES: 2:1 ratio', () => {
+    const expenses = [
+      makeExpense({
+        amount: 3000,
+        paidBy: alice,
+        paidFor: [
+          { participant: alice, shares: 1000 },
+          { participant: bob, shares: 1000 },
+          { participant: charlie, shares: 1000 },
+        ],
+        splitMode: 'BY_AMOUNT',
+        paidByList: [
+          { participant: alice, shares: 200 },
+          { participant: bob, shares: 100 },
+        ],
+        paidBySplitMode: 'BY_SHARES',
+      }),
+    ]
+
+    const balances = getBalances(expenses)
+    expect(balances[alice.id].paid).toBe(2000)
+    expect(balances[alice.id].total).toBe(1000)
+    expect(balances[bob.id].paid).toBe(1000)
+    expect(balances[bob.id].total).toBe(0)
+  })
+
+  it('should handle paidFor splitMode EVENLY with multi-payer', () => {
+    const expenses = [
+      makeExpense({
+        amount: 3000,
+        paidBy: alice,
+        paidFor: [
+          { participant: alice, shares: 1 },
+          { participant: bob, shares: 1 },
+          { participant: charlie, shares: 1 },
+        ],
+        splitMode: 'EVENLY',
+        paidByList: [
+          { participant: alice, shares: 2000 },
+          { participant: bob, shares: 1000 },
+        ],
+        paidBySplitMode: 'BY_AMOUNT',
+      }),
+    ]
+
+    const balances = getBalances(expenses)
+    expect(balances[alice.id].paidFor).toBe(1000)
+    expect(balances[bob.id].paidFor).toBe(1000)
+    expect(balances[charlie.id].paidFor).toBe(1000)
+    expect(balances[alice.id].paid).toBe(2000)
+    expect(balances[bob.id].paid).toBe(1000)
+  })
+
+  it('should handle paidFor splitMode BY_SHARES with multi-payer', () => {
+    const expenses = [
+      makeExpense({
+        amount: 6000,
+        paidBy: alice,
+        paidFor: [
+          { participant: alice, shares: 200 },
+          { participant: bob, shares: 100 },
+        ],
+        splitMode: 'BY_SHARES',
+        paidByList: [
+          { participant: alice, shares: 3000 },
+          { participant: bob, shares: 3000 },
+        ],
+        paidBySplitMode: 'BY_AMOUNT',
+      }),
+    ]
+
+    const balances = getBalances(expenses)
+    // BY_SHARES: alice 2/3 = 4000, bob 1/3 = 2000
+    expect(balances[alice.id].paidFor).toBe(4000)
+    expect(balances[bob.id].paidFor).toBe(2000)
+    expect(balances[alice.id].paid).toBe(3000)
+    expect(balances[bob.id].paid).toBe(3000)
+  })
+
+  it('should handle paidFor splitMode BY_PERCENTAGE with multi-payer', () => {
+    const expenses = [
+      makeExpense({
+        amount: 10000,
+        paidBy: alice,
+        paidFor: [
+          { participant: alice, shares: 6000 }, // 60%
+          { participant: bob, shares: 4000 }, // 40%
+        ],
+        splitMode: 'BY_PERCENTAGE',
+        paidByList: [
+          { participant: alice, shares: 5000 },
+          { participant: bob, shares: 5000 },
+        ],
+        paidBySplitMode: 'BY_AMOUNT',
+      }),
+    ]
+
+    const balances = getBalances(expenses)
+    expect(balances[alice.id].paidFor).toBe(6000)
+    expect(balances[bob.id].paidFor).toBe(4000)
+  })
+
+  it('should handle payer in paidByList but NOT in paidFor', () => {
+    const expenses = [
+      makeExpense({
+        amount: 2000,
+        paidBy: alice,
+        paidFor: [{ participant: bob, shares: 2000 }],
+        splitMode: 'BY_AMOUNT',
+        paidByList: [{ participant: alice, shares: 2000 }],
+        paidBySplitMode: 'BY_AMOUNT',
+      }),
+    ]
+
+    const balances = getBalances(expenses)
+    expect(balances[alice.id].paid).toBe(2000)
+    expect(balances[alice.id].paidFor).toBe(0)
+    expect(balances[alice.id].total).toBe(2000)
+    expect(balances[bob.id].paid).toBe(0)
+    expect(balances[bob.id].paidFor).toBe(2000)
+    expect(balances[bob.id].total).toBe(-2000)
+  })
+
+  it('should handle participant in paidFor but NOT in paidByList', () => {
+    const expenses = [
+      makeExpense({
+        amount: 3000,
+        paidBy: alice,
+        paidFor: [
+          { participant: alice, shares: 1000 },
+          { participant: bob, shares: 1000 },
+          { participant: charlie, shares: 1000 },
+        ],
+        splitMode: 'BY_AMOUNT',
+        paidByList: [{ participant: alice, shares: 3000 }],
+        paidBySplitMode: 'BY_AMOUNT',
+      }),
+    ]
+
+    const balances = getBalances(expenses)
+    expect(balances[charlie.id].paid).toBe(0)
+    expect(balances[charlie.id].paidFor).toBe(1000)
+    expect(balances[charlie.id].total).toBe(-1000)
+  })
+
+  it('should handle rounding with even multi-payer split', () => {
+    const expenses = [
+      makeExpense({
+        amount: 1200,
+        paidBy: alice,
+        paidFor: [{ participant: charlie, shares: 1200 }],
+        splitMode: 'BY_AMOUNT',
+        paidByList: [
+          { participant: alice, shares: 1 },
+          { participant: bob, shares: 1 },
+        ],
+        paidBySplitMode: 'EVENLY',
+      }),
+    ]
+
+    const balances = getBalances(expenses)
+    expect(balances[alice.id].paid).toBe(600)
+    expect(balances[bob.id].paid).toBe(600)
+    expect(balances[alice.id].paid + balances[bob.id].paid).toBe(1200)
+  })
+
+  it('should handle odd amount 3-way split with remaining going to last payer', () => {
+    const expenses = [
+      makeExpense({
+        amount: 1001,
+        paidBy: alice,
+        paidFor: [{ participant: charlie, shares: 1001 }],
+        splitMode: 'BY_AMOUNT',
+        paidByList: [
+          { participant: alice, shares: 1 },
+          { participant: bob, shares: 1 },
+          { participant: charlie, shares: 1 },
+        ],
+        paidBySplitMode: 'EVENLY',
+      }),
+    ]
+
+    const balances = getBalances(expenses)
+    const totalPaid =
+      balances[alice.id].paid +
+      balances[bob.id].paid +
+      balances[charlie.id].paid
+    expect(Math.abs(totalPaid - 1001)).toBeLessThanOrEqual(1)
+  })
+
+  it('should always have net zero sum of all balances', () => {
+    const expenses = [
+      makeExpense({
+        amount: 9999,
+        paidBy: alice,
+        paidFor: [
+          { participant: alice, shares: 3333 },
+          { participant: bob, shares: 3333 },
+          { participant: charlie, shares: 3333 },
+        ],
+        splitMode: 'BY_AMOUNT',
+        paidByList: [
+          { participant: alice, shares: 5000 },
+          { participant: bob, shares: 4999 },
+        ],
+        paidBySplitMode: 'BY_AMOUNT',
+      }),
+    ]
+
+    const balances = getBalances(expenses)
+    const totalBalance = Object.values(balances).reduce(
+      (sum, b) => sum + b.total,
+      0,
+    )
+    expect(totalBalance).toBe(0)
+  })
+
+  it('should avoid negative zeros in balances', () => {
+    const expenses = [
+      makeExpense({
+        amount: 1000,
+        paidBy: alice,
+        paidFor: [{ participant: alice, shares: 1000 }],
+        splitMode: 'BY_AMOUNT',
+      }),
+    ]
+
+    const balances = getBalances(expenses)
+    // paid and paidFor should be 1000, total should be 0 (not -0)
+    expect(Object.is(balances[alice.id].total, -0)).toBe(false)
+    expect(balances[alice.id].total).toBe(0)
+  })
+
+  it('should handle multiple expenses with multi-payer', () => {
+    const expenses = [
+      makeExpense({
+        amount: 2000,
+        paidBy: alice,
+        paidFor: [
+          { participant: alice, shares: 1000 },
+          { participant: bob, shares: 1000 },
+        ],
+        splitMode: 'BY_AMOUNT',
+        paidByList: [
+          { participant: alice, shares: 1200 },
+          { participant: bob, shares: 800 },
+        ],
+        paidBySplitMode: 'BY_AMOUNT',
+      }),
+      makeExpense({
+        amount: 1000,
+        paidBy: bob,
+        paidFor: [
+          { participant: alice, shares: 500 },
+          { participant: bob, shares: 500 },
+        ],
+        splitMode: 'BY_AMOUNT',
+        paidByList: [{ participant: bob, shares: 1000 }],
+        paidBySplitMode: 'BY_AMOUNT',
+      }),
+    ]
+
+    const balances = getBalances(expenses)
+    expect(balances[alice.id].paid).toBe(1200)
+    expect(balances[alice.id].paidFor).toBe(1500)
+    expect(balances[alice.id].total).toBe(-300)
+    expect(balances[bob.id].paid).toBe(1800)
+    expect(balances[bob.id].paidFor).toBe(1500)
+    expect(balances[bob.id].total).toBe(300)
+  })
+})
+
+describe('getPublicBalances', () => {
+  it('should return empty object for empty reimbursements', () => {
+    expect(getPublicBalances([])).toEqual({})
+  })
+
+  it('should compute balances from a single reimbursement', () => {
+    const balances = getPublicBalances([
+      { from: alice.id, to: bob.id, amount: 500 },
+    ])
+    expect(balances[alice.id].paidFor).toBe(500)
+    expect(balances[alice.id].total).toBe(-500)
+    expect(balances[bob.id].paid).toBe(500)
+    expect(balances[bob.id].total).toBe(500)
+  })
+
+  it('should accumulate across multiple reimbursements', () => {
+    const balances = getPublicBalances([
+      { from: alice.id, to: bob.id, amount: 300 },
+      { from: charlie.id, to: bob.id, amount: 700 },
+    ])
+    expect(balances[bob.id].paid).toBe(1000)
+    expect(balances[bob.id].total).toBe(1000)
+    expect(balances[alice.id].total).toBe(-300)
+    expect(balances[charlie.id].total).toBe(-700)
+  })
+
+  it('should handle same participant as both sender and receiver across reimbursements', () => {
+    const balances = getPublicBalances([
+      { from: alice.id, to: bob.id, amount: 500 },
+      { from: bob.id, to: alice.id, amount: 200 },
+    ])
+    expect(balances[alice.id].paidFor).toBe(500)
+    expect(balances[alice.id].paid).toBe(200)
+    expect(balances[alice.id].total).toBe(-300)
+    expect(balances[bob.id].paidFor).toBe(200)
+    expect(balances[bob.id].paid).toBe(500)
+    expect(balances[bob.id].total).toBe(300)
+  })
+})
+
+describe('getSuggestedReimbursements', () => {
+  it('should return empty for all-zero balances', () => {
+    const balances = getBalances([
+      makeExpense({
+        amount: 1000,
+        paidBy: alice,
+        paidFor: [{ participant: alice, shares: 1000 }],
+        splitMode: 'BY_AMOUNT',
+      }),
+    ])
+    expect(getSuggestedReimbursements(balances)).toEqual([])
+  })
+
+  it('should return empty for empty balances', () => {
+    expect(getSuggestedReimbursements({})).toEqual([])
+  })
+
+  it('should produce correct reimbursements for multi-payer expenses', () => {
+    const expenses = [
+      makeExpense({
+        amount: 3000,
+        paidBy: alice,
+        paidFor: [
+          { participant: alice, shares: 1000 },
+          { participant: bob, shares: 1000 },
+          { participant: charlie, shares: 1000 },
+        ],
+        splitMode: 'BY_AMOUNT',
+        paidByList: [
+          { participant: alice, shares: 2000 },
+          { participant: bob, shares: 1000 },
+        ],
+        paidBySplitMode: 'BY_AMOUNT',
+      }),
+    ]
+
+    const balances = getBalances(expenses)
+    const reimbursements = getSuggestedReimbursements(balances)
+
+    // Alice: +1000, Bob: 0, Charlie: -1000
+    expect(reimbursements).toHaveLength(1)
+    expect(reimbursements[0]).toEqual({
+      from: charlie.id,
+      to: alice.id,
+      amount: 1000,
+    })
+  })
+
+  it('should handle multiple debtors and multiple creditors', () => {
+    const expenses = [
+      makeExpense({
+        amount: 4000,
+        paidBy: alice,
+        paidFor: [
+          { participant: alice, shares: 1000 },
+          { participant: bob, shares: 1000 },
+          { participant: charlie, shares: 1000 },
+          { participant: dave, shares: 1000 },
+        ],
+        splitMode: 'BY_AMOUNT',
+        paidByList: [
+          { participant: alice, shares: 2500 },
+          { participant: bob, shares: 1500 },
+        ],
+        paidBySplitMode: 'BY_AMOUNT',
+      }),
+    ]
+
+    const balances = getBalances(expenses)
+    // Alice: paid 2500, owes 1000 → +1500
+    // Bob: paid 1500, owes 1000 → +500
+    // Charlie: paid 0, owes 1000 → -1000
+    // Dave: paid 0, owes 1000 → -1000
+    const reimbursements = getSuggestedReimbursements(balances)
+
+    // Total reimbursed should equal total owed
+    const totalReimbursed = reimbursements.reduce((s, r) => s + r.amount, 0)
+    expect(totalReimbursed).toBe(2000)
+    expect(reimbursements.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('should filter out near-zero reimbursements from rounding', () => {
+    // Manually construct balances with tiny residuals
+    const balances = {
+      [alice.id]: { paid: 1000, paidFor: 1000, total: 0.0001 },
+      [bob.id]: { paid: 1000, paidFor: 1000, total: -0.0001 },
+    }
+    const reimbursements = getSuggestedReimbursements(balances)
+    expect(reimbursements).toEqual([])
+  })
+})

--- a/src/lib/balances.ts
+++ b/src/lib/balances.ts
@@ -19,18 +19,52 @@ export function getBalances(
   const balances: Balances = {}
 
   for (const expense of expenses) {
-    const paidBy = expense.paidBy.id
     const paidFors = expense.paidFor
+    const paidByList = expense.paidByList ?? []
 
-    if (!balances[paidBy]) balances[paidBy] = { paid: 0, paidFor: 0, total: 0 }
-    balances[paidBy].paid += expense.amount
+    // Distribute paid amounts across payers using paidBySplitMode
+    if (paidByList.length > 0) {
+      const totalPaidByShares = paidByList.reduce(
+        (sum: number, p: any) => sum + p.shares,
+        0,
+      )
+      let paidRemaining = expense.amount
+      paidByList.forEach((paidByEntry: any, index: number) => {
+        const payerId = paidByEntry.participant.id
+        if (!balances[payerId])
+          balances[payerId] = { paid: 0, paidFor: 0, total: 0 }
 
+        const isLast = index === paidByList.length - 1
+        const paidBySplitMode = expense.paidBySplitMode ?? 'BY_AMOUNT'
+
+        const [shares, totalShares] = match(paidBySplitMode)
+          .with('EVENLY', () => [1, paidByList.length])
+          .with('BY_SHARES', () => [paidByEntry.shares, totalPaidByShares])
+          .with('BY_PERCENTAGE', () => [paidByEntry.shares, totalPaidByShares])
+          .with('BY_AMOUNT', () => [paidByEntry.shares, totalPaidByShares])
+          .exhaustive()
+
+        const paidAmount = isLast
+          ? paidRemaining
+          : (expense.amount * shares) / totalShares
+        paidRemaining -= paidAmount
+        balances[payerId].paid += paidAmount
+      })
+    } else {
+      // Fallback for expenses without paidByList (legacy)
+      const paidBy = expense.paidBy.id
+      if (!balances[paidBy])
+        balances[paidBy] = { paid: 0, paidFor: 0, total: 0 }
+      balances[paidBy].paid += expense.amount
+    }
+
+    // Distribute owed amounts across payees using splitMode
     const totalPaidForShares = paidFors.reduce(
-      (sum, paidFor) => sum + paidFor.shares,
+      (sum: number, paidFor: any) => sum + paidFor.shares,
       0,
     )
     let remaining = expense.amount
-    paidFors.forEach((paidFor, index) => {
+    paidFors.forEach((paidFor: any, index: number) => {
       if (!balances[paidFor.participant.id])
         balances[paidFor.participant.id] = { paid: 0, paidFor: 0, total: 0 }
 

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -85,7 +85,55 @@ export const expenseFormSchema = z
         inputCoercedToNumber.refine((amount) => amount > 0, 'ratePositive'),
       ])
       .optional(),
-    paidBy: z.string({ required_error: 'paidByRequired' }),
+    paidBy: z.string({ required_error: 'paidByRequired' }), // Single payer ID (used when isMultiPayer is false)
+    isMultiPayer: z.boolean().default(false),
+    paidByList: z
+      .array(
+        z.object({
+          participant: z.string(),
+          shares: z.union([
+            z.number(),
+            z.string().transform((value, ctx) => {
+              const normalizedValue = value.replace(/,/g, '.')
+              const valueAsNumber = Number(normalizedValue)
+              if (Number.isNaN(valueAsNumber))
+                ctx.addIssue({
+                  code: z.ZodIssueCode.custom,
+                  message: 'invalidNumber',
+                })
+              return value
+            }),
+          ]),
+        }),
+      )
+      .superRefine((paidByList, ctx) => {
+        for (const { shares } of paidByList) {
+          const shareNumber = Number(shares)
+          if (shareNumber <= 0) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: 'noZeroShares',
+            })
+          }
+        }
+        const seen = new Set<string>()
+        for (let i = 0; i < paidByList.length; i++) {
+          if (seen.has(paidByList[i].participant)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: 'duplicateParticipant',
+              path: [i, 'participant'],
+            })
+          }
+          seen.add(paidByList[i].participant)
+        }
+      })
+      .default([]),
+    paidBySplitMode: z
+      .enum<SplitMode, [SplitMode, ...SplitMode[]]>(
+        Object.values(SplitMode) as any,
+      )
+      .default('BY_AMOUNT'),
     paidFor: z
       .array(
         z.object({
@@ -143,6 +191,7 @@ export const expenseFormSchema = z
       .default('NONE'),
   })
   .superRefine((expense, ctx) => {
+    // Validate paidFor split
     switch (expense.splitMode) {
       case 'EVENLY':
         break // noop
@@ -154,10 +203,6 @@ export const expenseFormSchema = z
           new Decimal(0),
         )
         if (!sum.equals(new Decimal(expense.amount))) {
-          // const detail =
-          //   sum < expense.amount
-          //     ? `${((expense.amount - sum) / 100).toFixed(2)} missing`
-          //     : `${((sum - expense.amount) / 100).toFixed(2)} surplus`
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
             message: 'amountSum',
@@ -176,10 +221,6 @@ export const expenseFormSchema = z
           0,
         )
         if (sum !== 10000) {
-          const detail =
-            sum < 10000
-              ? `${((10000 - sum) / 100).toFixed(0)}% missing`
-              : `${((sum - 10000) / 100).toFixed(0)}% surplus`
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
             message: 'percentageSum',
@@ -187,6 +228,48 @@ export const expenseFormSchema = z
           })
         }
         break
+      }
+    }
+
+    // Validate paidByList split (only when multi-payer is active)
+    if (expense.isMultiPayer && expense.paidByList.length > 0) {
+      switch (expense.paidBySplitMode) {
+        case 'EVENLY':
+          break
+        case 'BY_SHARES':
+          break
+        case 'BY_AMOUNT': {
+          const sum = expense.paidByList.reduce(
+            (sum, { shares }) => new Decimal(shares).add(sum),
+            new Decimal(0),
+          )
+          if (!sum.equals(new Decimal(expense.amount))) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: 'paidByAmountSum',
+              path: ['paidByList'],
+            })
+          }
+          break
+        }
+        case 'BY_PERCENTAGE': {
+          const sum = expense.paidByList.reduce(
+            (sum, { shares }) =>
+              sum +
+              (typeof shares === 'string'
+                ? Math.round(Number(shares) * 100)
+                : Number(shares)),
+            0,
+          )
+          if (sum !== 10000) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: 'paidByPercentageSum',
+              path: ['paidByList'],
+            })
+          }
+          break
+        }
       }
     }
   })
@@ -209,6 +292,22 @@ export const expenseFormSchema = z
           shares: Number(shares),
         }
       }),
+      paidByList: expense.paidByList.map((paidBy) => {
+        const shares = paidBy.shares
+        if (
+          typeof shares === 'string' &&
+          expense.paidBySplitMode !== 'BY_AMOUNT'
+        ) {
+          return {
+            ...paidBy,
+            shares: Math.round(Number(shares) * 100),
+          }
+        }
+        return {
+          ...paidBy,
+          shares: Number(shares),
+        }
+      }),
     }
   })
 
@@ -218,4 +317,6 @@ export type SplittingOptions = {
   // Used for saving default splitting options in localStorage
   splitMode: SplitMode
   paidFor: ExpenseFormValues['paidFor'] | null
+  paidBySplitMode?: SplitMode
+  paidByList?: ExpenseFormValues['paidByList'] | null
 }

--- a/src/lib/test-helpers.ts
+++ b/src/lib/test-helpers.ts
@@ -1,0 +1,45 @@
+type SplitMode = 'EVENLY' | 'BY_SHARES' | 'BY_PERCENTAGE' | 'BY_AMOUNT'
+
+export type TestParticipant = { id: string; name: string }
+
+export const alice: TestParticipant = { id: 'alice', name: 'Alice' }
+export const bob: TestParticipant = { id: 'bob', name: 'Bob' }
+export const charlie: TestParticipant = { id: 'charlie', name: 'Charlie' }
+export const dave: TestParticipant = { id: 'dave', name: 'Dave' }
+
+let expenseCounter = 0
+
+export function makeExpense({
+  amount,
+  paidBy,
+  paidFor,
+  splitMode = 'EVENLY' as const,
+  isReimbursement = false,
+  paidByList,
+  paidBySplitMode = 'BY_AMOUNT' as const,
+}: {
+  amount: number
+  paidBy: TestParticipant
+  paidFor: { participant: TestParticipant; shares: number }[]
+  splitMode?: SplitMode
+  isReimbursement?: boolean
+  paidByList?: { participant: TestParticipant; shares: number }[]
+  paidBySplitMode?: SplitMode
+}) {
+  return {
+    id: `exp-${++expenseCounter}`,
+    amount,
+    paidBy,
+    paidFor,
+    splitMode,
+    isReimbursement,
+    paidByList: paidByList ?? [{ participant: paidBy, shares: amount }],
+    paidBySplitMode: paidByList ? paidBySplitMode : 'BY_AMOUNT',
+    title: 'Test',
+    expenseDate: new Date(),
+    createdAt: new Date(),
+    category: null,
+    recurrenceRule: 'NONE',
+    _count: { documents: 0 },
+  } as any
+}

--- a/src/lib/totals.test.ts
+++ b/src/lib/totals.test.ts
@@ -1,11 +1,11 @@
-import {
-  getTotalActiveUserPaidFor,
-  getTotalGroupSpending,
-  calculateShare,
-  calculatePaidByShare,
-  getTotalActiveUserShare,
-} from './totals'
 import { alice, bob, charlie, makeExpense } from './test-helpers'
+import {
+  calculatePaidByShare,
+  calculateShare,
+  getTotalActiveUserPaidFor,
+  getTotalActiveUserShare,
+  getTotalGroupSpending,
+} from './totals'
 
 // ─── getTotalGroupSpending ───────────────────────────────────────────
 

--- a/src/lib/totals.test.ts
+++ b/src/lib/totals.test.ts
@@ -1,0 +1,485 @@
+import {
+  getTotalActiveUserPaidFor,
+  getTotalGroupSpending,
+  calculateShare,
+  calculatePaidByShare,
+  getTotalActiveUserShare,
+} from './totals'
+import { alice, bob, charlie, makeExpense } from './test-helpers'
+
+// ─── getTotalGroupSpending ───────────────────────────────────────────
+
+describe('getTotalGroupSpending', () => {
+  it('returns 0 for empty expenses', () => {
+    expect(getTotalGroupSpending([])).toBe(0)
+  })
+
+  it('sums expense amounts (ignoring multi-payer details)', () => {
+    const expenses = [
+      makeExpense({
+        amount: 3000,
+        paidBy: alice,
+        paidFor: [{ participant: alice, shares: 3000 }],
+        splitMode: 'BY_AMOUNT',
+        paidByList: [
+          { participant: alice, shares: 2000 },
+          { participant: bob, shares: 1000 },
+        ],
+        paidBySplitMode: 'BY_AMOUNT',
+      }),
+    ]
+    expect(getTotalGroupSpending(expenses)).toBe(3000)
+  })
+
+  it('excludes reimbursements', () => {
+    const expenses = [
+      makeExpense({
+        amount: 5000,
+        paidBy: alice,
+        paidFor: [{ participant: bob, shares: 5000 }],
+        splitMode: 'BY_AMOUNT',
+      }),
+      makeExpense({
+        amount: 2000,
+        paidBy: bob,
+        paidFor: [{ participant: alice, shares: 2000 }],
+        splitMode: 'BY_AMOUNT',
+        isReimbursement: true,
+      }),
+    ]
+    expect(getTotalGroupSpending(expenses)).toBe(5000)
+  })
+
+  it('returns 0 when all expenses are reimbursements', () => {
+    const expenses = [
+      makeExpense({
+        amount: 1000,
+        paidBy: alice,
+        paidFor: [{ participant: bob, shares: 1000 }],
+        splitMode: 'BY_AMOUNT',
+        isReimbursement: true,
+      }),
+    ]
+    expect(getTotalGroupSpending(expenses)).toBe(0)
+  })
+
+  it('sums multiple non-reimbursement expenses', () => {
+    const expenses = [
+      makeExpense({
+        amount: 1000,
+        paidBy: alice,
+        paidFor: [{ participant: bob, shares: 1000 }],
+        splitMode: 'BY_AMOUNT',
+      }),
+      makeExpense({
+        amount: 2000,
+        paidBy: bob,
+        paidFor: [{ participant: alice, shares: 2000 }],
+        splitMode: 'BY_AMOUNT',
+      }),
+    ]
+    expect(getTotalGroupSpending(expenses)).toBe(3000)
+  })
+})
+
+// ─── getTotalActiveUserPaidFor ───────────────────────────────────────
+
+describe('getTotalActiveUserPaidFor', () => {
+  it('returns 0 for empty expenses', () => {
+    expect(getTotalActiveUserPaidFor(alice.id, [])).toBe(0)
+  })
+
+  it('returns 0 for null activeUserId', () => {
+    const expenses = [
+      makeExpense({
+        amount: 3000,
+        paidBy: alice,
+        paidFor: [{ participant: alice, shares: 3000 }],
+        splitMode: 'BY_AMOUNT',
+      }),
+    ]
+    expect(getTotalActiveUserPaidFor(null, expenses)).toBe(0)
+  })
+
+  it('calculates partial paid amount for multi-payer BY_AMOUNT', () => {
+    const expenses = [
+      makeExpense({
+        amount: 3000,
+        paidBy: alice,
+        paidFor: [{ participant: alice, shares: 3000 }],
+        splitMode: 'BY_AMOUNT',
+        paidByList: [
+          { participant: alice, shares: 2000 },
+          { participant: bob, shares: 1000 },
+        ],
+        paidBySplitMode: 'BY_AMOUNT',
+      }),
+    ]
+    expect(getTotalActiveUserPaidFor(alice.id, expenses)).toBe(2000)
+    expect(getTotalActiveUserPaidFor(bob.id, expenses)).toBe(1000)
+  })
+
+  it('calculates partial paid amount for multi-payer EVENLY', () => {
+    const expenses = [
+      makeExpense({
+        amount: 3000,
+        paidBy: alice,
+        paidFor: [{ participant: alice, shares: 3000 }],
+        splitMode: 'BY_AMOUNT',
+        paidByList: [
+          { participant: alice, shares: 1 },
+          { participant: bob, shares: 1 },
+        ],
+        paidBySplitMode: 'EVENLY',
+      }),
+    ]
+    expect(getTotalActiveUserPaidFor(alice.id, expenses)).toBe(1500)
+    expect(getTotalActiveUserPaidFor(bob.id, expenses)).toBe(1500)
+  })
+
+  it('calculates partial paid amount for multi-payer BY_PERCENTAGE', () => {
+    const expenses = [
+      makeExpense({
+        amount: 10000,
+        paidBy: alice,
+        paidFor: [{ participant: alice, shares: 10000 }],
+        splitMode: 'BY_AMOUNT',
+        paidByList: [
+          { participant: alice, shares: 7000 }, // 70%
+          { participant: bob, shares: 3000 }, // 30%
+        ],
+        paidBySplitMode: 'BY_PERCENTAGE',
+      }),
+    ]
+    expect(getTotalActiveUserPaidFor(alice.id, expenses)).toBe(7000)
+    expect(getTotalActiveUserPaidFor(bob.id, expenses)).toBe(3000)
+  })
+
+  it('calculates partial paid amount for multi-payer BY_SHARES', () => {
+    const expenses = [
+      makeExpense({
+        amount: 3000,
+        paidBy: alice,
+        paidFor: [{ participant: alice, shares: 3000 }],
+        splitMode: 'BY_AMOUNT',
+        paidByList: [
+          { participant: alice, shares: 2 }, // 2/3
+          { participant: bob, shares: 1 }, // 1/3
+        ],
+        paidBySplitMode: 'BY_SHARES',
+      }),
+    ]
+    expect(getTotalActiveUserPaidFor(alice.id, expenses)).toBe(2000)
+    expect(getTotalActiveUserPaidFor(bob.id, expenses)).toBe(1000)
+  })
+
+  it('excludes reimbursements', () => {
+    const expenses = [
+      makeExpense({
+        amount: 3000,
+        paidBy: alice,
+        paidFor: [{ participant: bob, shares: 3000 }],
+        splitMode: 'BY_AMOUNT',
+        isReimbursement: true,
+      }),
+    ]
+    expect(getTotalActiveUserPaidFor(alice.id, expenses)).toBe(0)
+  })
+
+  it('falls back to legacy single-payer when paidByList is empty', () => {
+    const expense = makeExpense({
+      amount: 5000,
+      paidBy: alice,
+      paidFor: [{ participant: bob, shares: 5000 }],
+      splitMode: 'BY_AMOUNT',
+    })
+    // Override paidByList to be empty to test legacy path
+    ;(expense as any).paidByList = []
+
+    expect(getTotalActiveUserPaidFor(alice.id, [expense])).toBe(5000)
+    expect(getTotalActiveUserPaidFor(bob.id, [expense])).toBe(0)
+  })
+
+  it('accumulates across multiple expenses', () => {
+    const expenses = [
+      makeExpense({
+        amount: 2000,
+        paidBy: alice,
+        paidFor: [{ participant: bob, shares: 2000 }],
+        splitMode: 'BY_AMOUNT',
+      }),
+      makeExpense({
+        amount: 3000,
+        paidBy: alice,
+        paidFor: [{ participant: bob, shares: 3000 }],
+        splitMode: 'BY_AMOUNT',
+      }),
+    ]
+    expect(getTotalActiveUserPaidFor(alice.id, expenses)).toBe(5000)
+  })
+
+  it('returns 0 when user is not a payer in any expense', () => {
+    const expenses = [
+      makeExpense({
+        amount: 3000,
+        paidBy: alice,
+        paidFor: [{ participant: bob, shares: 3000 }],
+        splitMode: 'BY_AMOUNT',
+      }),
+    ]
+    expect(getTotalActiveUserPaidFor(charlie.id, expenses)).toBe(0)
+  })
+})
+
+// ─── calculatePaidByShare ────────────────────────────────────────────
+
+describe('calculatePaidByShare', () => {
+  it('returns 0 when participant is not in paidByList', () => {
+    expect(
+      calculatePaidByShare(charlie.id, {
+        amount: 3000,
+        paidByList: [{ participant: alice, shares: 3000 }],
+        paidBySplitMode: 'BY_AMOUNT',
+      }),
+    ).toBe(0)
+  })
+
+  it('returns 0 for null participantId', () => {
+    expect(
+      calculatePaidByShare(null, {
+        amount: 3000,
+        paidByList: [{ participant: alice, shares: 3000 }],
+        paidBySplitMode: 'BY_AMOUNT',
+      }),
+    ).toBe(0)
+  })
+
+  it('BY_AMOUNT: returns shares directly', () => {
+    expect(
+      calculatePaidByShare(alice.id, {
+        amount: 5000,
+        paidByList: [
+          { participant: alice, shares: 3000 },
+          { participant: bob, shares: 2000 },
+        ],
+        paidBySplitMode: 'BY_AMOUNT',
+      }),
+    ).toBe(3000)
+  })
+
+  it('EVENLY: divides amount equally among payers', () => {
+    expect(
+      calculatePaidByShare(alice.id, {
+        amount: 3000,
+        paidByList: [
+          { participant: alice, shares: 1 },
+          { participant: bob, shares: 1 },
+          { participant: charlie, shares: 1 },
+        ],
+        paidBySplitMode: 'EVENLY',
+      }),
+    ).toBe(1000)
+  })
+
+  it('BY_PERCENTAGE: calculates proportional amount', () => {
+    expect(
+      calculatePaidByShare(alice.id, {
+        amount: 10000,
+        paidByList: [
+          { participant: alice, shares: 6000 }, // 60%
+          { participant: bob, shares: 4000 }, // 40%
+        ],
+        paidBySplitMode: 'BY_PERCENTAGE',
+      }),
+    ).toBe(6000)
+  })
+
+  it('BY_SHARES: calculates proportional amount by shares', () => {
+    expect(
+      calculatePaidByShare(alice.id, {
+        amount: 6000,
+        paidByList: [
+          { participant: alice, shares: 2 },
+          { participant: bob, shares: 1 },
+        ],
+        paidBySplitMode: 'BY_SHARES',
+      }),
+    ).toBe(4000)
+  })
+
+  it('returns 0 for unknown split mode', () => {
+    expect(
+      calculatePaidByShare(alice.id, {
+        amount: 3000,
+        paidByList: [{ participant: alice, shares: 3000 }],
+        paidBySplitMode: 'UNKNOWN' as any,
+      }),
+    ).toBe(0)
+  })
+})
+
+// ─── calculateShare ──────────────────────────────────────────────────
+
+describe('calculateShare', () => {
+  it('returns 0 when participant is not in paidFor', () => {
+    const expense = makeExpense({
+      amount: 3000,
+      paidBy: alice,
+      paidFor: [{ participant: alice, shares: 3000 }],
+      splitMode: 'BY_AMOUNT',
+    })
+    expect(calculateShare(charlie.id, expense)).toBe(0)
+  })
+
+  it('returns 0 for null participantId', () => {
+    const expense = makeExpense({
+      amount: 3000,
+      paidBy: alice,
+      paidFor: [{ participant: alice, shares: 3000 }],
+      splitMode: 'BY_AMOUNT',
+    })
+    expect(calculateShare(null, expense)).toBe(0)
+  })
+
+  it('returns 0 for reimbursements', () => {
+    const expense = makeExpense({
+      amount: 3000,
+      paidBy: alice,
+      paidFor: [{ participant: bob, shares: 3000 }],
+      splitMode: 'BY_AMOUNT',
+      isReimbursement: true,
+    })
+    expect(calculateShare(bob.id, expense)).toBe(0)
+  })
+
+  it('BY_AMOUNT: returns shares directly', () => {
+    const expense = makeExpense({
+      amount: 3000,
+      paidBy: alice,
+      paidFor: [
+        { participant: alice, shares: 1500 },
+        { participant: bob, shares: 1500 },
+      ],
+      splitMode: 'BY_AMOUNT',
+    })
+    expect(calculateShare(alice.id, expense)).toBe(1500)
+    expect(calculateShare(bob.id, expense)).toBe(1500)
+  })
+
+  it('EVENLY: divides amount equally among participants', () => {
+    const expense = makeExpense({
+      amount: 3000,
+      paidBy: alice,
+      paidFor: [
+        { participant: alice, shares: 1 },
+        { participant: bob, shares: 1 },
+        { participant: charlie, shares: 1 },
+      ],
+      splitMode: 'EVENLY',
+    })
+    expect(calculateShare(alice.id, expense)).toBe(1000)
+    expect(calculateShare(bob.id, expense)).toBe(1000)
+  })
+
+  it('BY_PERCENTAGE: calculates proportional amount', () => {
+    const expense = makeExpense({
+      amount: 10000,
+      paidBy: alice,
+      paidFor: [
+        { participant: alice, shares: 6000 }, // 60% (shares stored as basis points)
+        { participant: bob, shares: 4000 }, // 40%
+      ],
+      splitMode: 'BY_PERCENTAGE',
+    })
+    expect(calculateShare(alice.id, expense)).toBe(6000)
+    expect(calculateShare(bob.id, expense)).toBe(4000)
+  })
+
+  it('BY_SHARES: calculates proportional amount by shares', () => {
+    const expense = makeExpense({
+      amount: 6000,
+      paidBy: alice,
+      paidFor: [
+        { participant: alice, shares: 2 },
+        { participant: bob, shares: 1 },
+      ],
+      splitMode: 'BY_SHARES',
+    })
+    expect(calculateShare(alice.id, expense)).toBe(4000)
+    expect(calculateShare(bob.id, expense)).toBe(2000)
+  })
+})
+
+// ─── getTotalActiveUserShare ─────────────────────────────────────────
+
+describe('getTotalActiveUserShare', () => {
+  it('returns 0 for empty expenses', () => {
+    expect(getTotalActiveUserShare(alice.id, [])).toBe(0)
+  })
+
+  it('returns 0 for null activeUserId', () => {
+    const expenses = [
+      makeExpense({
+        amount: 3000,
+        paidBy: alice,
+        paidFor: [{ participant: alice, shares: 3000 }],
+        splitMode: 'BY_AMOUNT',
+      }),
+    ]
+    expect(getTotalActiveUserShare(null, expenses)).toBe(0)
+  })
+
+  it('sums shares across multiple expenses', () => {
+    const expenses = [
+      makeExpense({
+        amount: 2000,
+        paidBy: alice,
+        paidFor: [
+          { participant: alice, shares: 1000 },
+          { participant: bob, shares: 1000 },
+        ],
+        splitMode: 'BY_AMOUNT',
+      }),
+      makeExpense({
+        amount: 3000,
+        paidBy: bob,
+        paidFor: [
+          { participant: alice, shares: 1500 },
+          { participant: bob, shares: 1500 },
+        ],
+        splitMode: 'BY_AMOUNT',
+      }),
+    ]
+    expect(getTotalActiveUserShare(alice.id, expenses)).toBe(2500)
+  })
+
+  it('excludes reimbursements', () => {
+    const expenses = [
+      makeExpense({
+        amount: 3000,
+        paidBy: alice,
+        paidFor: [{ participant: bob, shares: 3000 }],
+        splitMode: 'BY_AMOUNT',
+        isReimbursement: true,
+      }),
+    ]
+    expect(getTotalActiveUserShare(bob.id, expenses)).toBe(0)
+  })
+
+  it('rounds to 2 decimal places', () => {
+    const expenses = [
+      makeExpense({
+        amount: 1000,
+        paidBy: alice,
+        paidFor: [
+          { participant: alice, shares: 1 },
+          { participant: bob, shares: 1 },
+          { participant: charlie, shares: 1 },
+        ],
+        splitMode: 'EVENLY',
+      }),
+    ]
+    // 1000/3 = 333.333... → rounded to 333.33
+    expect(getTotalActiveUserShare(alice.id, expenses)).toBe(333.33)
+  })
+})

--- a/src/lib/totals.ts
+++ b/src/lib/totals.ts
@@ -14,13 +14,50 @@ export function getTotalActiveUserPaidFor(
   activeUserId: string | null,
   expenses: NonNullable<Awaited<ReturnType<typeof getGroupExpenses>>>,
 ): number {
-  return expenses.reduce(
-    (total, expense) =>
-      expense.paidBy.id === activeUserId && !expense.isReimbursement
-        ? total + expense.amount
-        : total,
-    0,
+  return expenses.reduce((total, expense) => {
+    if (expense.isReimbursement) return total
+
+    const paidByList = (expense as any).paidByList
+    if (paidByList && paidByList.length > 0) {
+      return total + calculatePaidByShare(activeUserId, expense as any)
+    }
+
+    // Legacy fallback: single payer
+    return expense.paidBy.id === activeUserId
+      ? total + expense.amount
+      : total
+  }, 0)
+}
+
+export function calculatePaidByShare(
+  participantId: string | null,
+  expense: {
+    amount: number
+    paidByList: { participant: { id: string }; shares: number }[]
+    paidBySplitMode: string
+  },
+): number {
+  const paidByList = expense.paidByList
+  const userPaidBy = paidByList.find(
+    (p) => p.participant.id === participantId,
   )
+
+  if (!userPaidBy) return 0
+
+  const totalShares = paidByList.reduce((sum, p) => sum + p.shares, 0)
+
+  switch (expense.paidBySplitMode) {
+    case 'EVENLY':
+      return expense.amount / paidByList.length
+    case 'BY_AMOUNT':
+      return userPaidBy.shares
+    case 'BY_PERCENTAGE':
+      return (expense.amount * userPaidBy.shares) / totalShares
+    case 'BY_SHARES':
+      return (expense.amount * userPaidBy.shares) / totalShares
+    default:
+      return 0
+  }
 }
 
 type Expense = NonNullable<Awaited<ReturnType<typeof getGroupExpenses>>>[number]

--- a/src/lib/totals.ts
+++ b/src/lib/totals.ts
@@ -23,9 +23,7 @@ export function getTotalActiveUserPaidFor(
     }
 
     // Legacy fallback: single payer
-    return expense.paidBy.id === activeUserId
-      ? total + expense.amount
-      : total
+    return expense.paidBy.id === activeUserId ? total + expense.amount : total
   }, 0)
 }
 
@@ -38,9 +36,7 @@ export function calculatePaidByShare(
   },
 ): number {
   const paidByList = expense.paidByList
-  const userPaidBy = paidByList.find(
-    (p) => p.participant.id === participantId,
-  )
+  const userPaidBy = paidByList.find((p) => p.participant.id === participantId)
 
   if (!userPaidBy) return 0
 


### PR DESCRIPTION
## Summary

- **Multi-payer expenses**: Allow an expense to be paid by multiple participants instead of just one, with support for EVENLY, BY_SHARES, BY_PERCENTAGE, and BY_AMOUNT split modes for the payer side
- **Full-stack implementation**: New `ExpensePaidBy` database model, updated Prisma schema with migration, extended tRPC API (create/update), balance & totals calculation, form UI with toggle, and CSV/JSON export support
- **i18n**: All 9 new translation keys added to all 23 locale files with proper translations
- **Tests**: 73 tests passing including comprehensive multi-payer balance and totals tests

## Changes

### Database
- New `ExpensePaidBy` model linking expenses to multiple paying participants with amounts
- Migration: `20250310_add_multi_payer_support`

### Backend
- `src/lib/api.ts`: Create/update expense handlers support `paidBy` array with split modes
- `src/lib/balances.ts`: Balance calculation accounts for multi-payer expenses
- `src/lib/totals.ts`: Totals/stats aggregate across multiple payers
- `src/lib/schemas.ts`: Zod schemas for multi-payer form validation

### Frontend
- `expense-form.tsx`: Multi-payer toggle, payer split mode selector, per-payer amount inputs
- `expense-card.tsx`: "Paid by X, Y for Z" display format
- CSV/JSON export includes multi-payer data

### i18n
- 9 keys across `ExpenseCard`, `ExpenseForm`, and `SchemaErrors` sections
- All 22 non-English locales translated

## Test plan

- [ ] Create a multi-payer expense with BY_AMOUNT split
- [ ] Create a multi-payer expense with EVENLY split
- [ ] Edit a multi-payer expense, toggle multi-payer off, save
- [ ] Edit a single-payer expense, toggle multi-payer on, save
- [ ] Verify balances page reflects multi-payer correctly
- [ ] Verify expense card shows "Paid by X, Y for Z" format
- [ ] CSV export includes multi-payer data
- [ ] JSON export includes multi-payer data
- [ ] Switch locale, verify translated strings appear