### PR TITLE
Add fixed monthly expense grouping setting

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -38,7 +38,8 @@
       "lastMonth": "Last month",
       "earlierThisYear": "Earlier this year",
       "lastYear": "Last year",
-      "older": "Older"
+      "older": "Older",
+      "currentMonth": "Current Month"
     }
   },
   "ExpenseCard": {
@@ -113,8 +114,12 @@
       "Jack": "Jack"
     },
     "Settings": {
-      "title": "Local settings",
-      "description": "These settings are set per-device, and are used to customize your experience.",
+      "title": "Settings",
+      "description": "Customize group-wide and per-device settings for this group.",
+      "FixedExpenseDateGroupsField": {
+        "label": "Group expenses by calendar month",
+        "description": "Useful for recurring monthly expenses for roommates and shared bills."
+      },
       "ActiveUserField": {
         "label": "Active user",
         "placeholder": "Select a participant",

--- a/prisma/migrations/20260623000000_add_fixed_expense_date_groups/migration.sql
+++ b/prisma/migrations/20260623000000_add_fixed_expense_date_groups/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Group" ADD COLUMN     "fixedExpenseDateGroups" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,15 +12,16 @@ datasource db {
 }
 
 model Group {
-  id           String        @id
-  name         String
-  information  String?       @db.Text
-  currency     String        @default("$")
-  currencyCode String?
-  participants Participant[]
-  expenses     Expense[]
-  activities   Activity[]
-  createdAt    DateTime      @default(now())
+  id                     String        @id
+  name                   String
+  information            String?       @db.Text
+  currency               String        @default("$")
+  currencyCode           String?
+  fixedExpenseDateGroups Boolean       @default(false)
+  participants           Participant[]
+  expenses               Expense[]
+  activities             Activity[]
+  createdAt              DateTime      @default(now())
 }
 
 model Participant {

--- a/src/app/groups/[groupId]/expenses/expense-list.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-list.tsx
@@ -4,10 +4,13 @@ import { getGroupExpensesAction } from '@/app/groups/[groupId]/expenses/expense-
 import { Button } from '@/components/ui/button'
 import { SearchBar } from '@/components/ui/search-bar'
 import { Skeleton } from '@/components/ui/skeleton'
+import {
+  getFixedMonthlyGroupedExpenses,
+  getRelativeGroupedExpenses,
+} from '@/lib/expense-date-groups'
 import { getCurrencyFromGroup } from '@/lib/utils'
 import { trpc } from '@/trpc/client'
-import dayjs, { type Dayjs } from 'dayjs'
-import { useTranslations } from 'next-intl'
+import { useLocale, useTranslations } from 'next-intl'
 import Link from 'next/link'
 import { forwardRef, useEffect, useMemo, useState } from 'react'
 import { useInView } from 'react-intersection-observer'
@@ -19,44 +22,6 @@ const PAGE_SIZE = 20
 type ExpensesType = NonNullable<
   Awaited<ReturnType<typeof getGroupExpensesAction>>
 >
-
-const EXPENSE_GROUPS = {
-  UPCOMING: 'upcoming',
-  THIS_WEEK: 'thisWeek',
-  EARLIER_THIS_MONTH: 'earlierThisMonth',
-  LAST_MONTH: 'lastMonth',
-  EARLIER_THIS_YEAR: 'earlierThisYear',
-  LAST_YEAR: 'lastYear',
-  OLDER: 'older',
-}
-
-function getExpenseGroup(date: Dayjs, today: Dayjs) {
-  if (today.isBefore(date)) {
-    return EXPENSE_GROUPS.UPCOMING
-  } else if (today.isSame(date, 'week')) {
-    return EXPENSE_GROUPS.THIS_WEEK
-  } else if (today.isSame(date, 'month')) {
-    return EXPENSE_GROUPS.EARLIER_THIS_MONTH
-  } else if (today.subtract(1, 'month').isSame(date, 'month')) {
-    return EXPENSE_GROUPS.LAST_MONTH
-  } else if (today.isSame(date, 'year')) {
-    return EXPENSE_GROUPS.EARLIER_THIS_YEAR
-  } else if (today.subtract(1, 'year').isSame(date, 'year')) {
-    return EXPENSE_GROUPS.LAST_YEAR
-  } else {
-    return EXPENSE_GROUPS.OLDER
-  }
-}
-
-function getGroupedExpensesByDate(expenses: ExpensesType) {
-  const today = dayjs()
-  return expenses.reduce((result: { [key: string]: ExpensesType }, expense) => {
-    const expenseGroup = getExpenseGroup(dayjs(expense.expenseDate), today)
-    result[expenseGroup] = result[expenseGroup] ?? []
-    result[expenseGroup].push(expense)
-    return result
-  }, {})
-}
 
 export function ExpenseList() {
   const { groupId, group } = useCurrentGroup()
@@ -114,6 +79,7 @@ const ExpenseListForSearch = ({
   }, [utils])
 
   const t = useTranslations('Expenses')
+  const locale = useLocale()
   const { ref: loadingRef, inView } = useInView()
 
   const {
@@ -133,9 +99,19 @@ const ExpenseListForSearch = ({
     if (inView && hasMore && !isLoading) fetchNextPage()
   }, [fetchNextPage, hasMore, inView, isLoading])
 
-  const groupedExpensesByDate = useMemo(
-    () => (expenses ? getGroupedExpensesByDate(expenses) : {}),
-    [expenses],
+  const expenseGroups = useMemo(
+    () =>
+      expenses
+        ? group?.fixedExpenseDateGroups
+          ? getFixedMonthlyGroupedExpenses(
+              expenses,
+              locale,
+              new Date(),
+              t('Groups.currentMonth'),
+            )
+          : getRelativeGroupedExpenses(expenses)
+        : [],
+    [expenses, group?.fixedExpenseDateGroups, locale, t],
   )
 
   if (isLoading) return <ExpensesLoading />
@@ -154,20 +130,17 @@ const ExpenseListForSearch = ({
 
   return (
     <>
-      {Object.values(EXPENSE_GROUPS).map((expenseGroup: string) => {
-        let groupExpenses = groupedExpensesByDate[expenseGroup]
-        if (!groupExpenses || groupExpenses.length === 0) return null
-
+      {expenseGroups.map((expenseGroup) => {
         return (
-          <div key={expenseGroup}>
+          <div key={expenseGroup.key}>
             <div
               className={
                 'text-muted-foreground text-xs pl-4 sm:pl-6 py-1 font-semibold sticky top-16 bg-white dark:bg-[#1b1917]'
               }
             >
-              {t(`Groups.${expenseGroup}`)}
+              {expenseGroup.label ?? t(`Groups.${expenseGroup.key}`)}
             </div>
-            {groupExpenses.map((expense) => (
+            {expenseGroup.expenses.map((expense) => (
               <ExpenseCard
                 key={expense.id}
                 expense={expense}

--- a/src/components/group-form.tsx
+++ b/src/components/group-form.tsx
@@ -8,6 +8,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
+import { Checkbox } from '@/components/ui/checkbox'
 import {
   Form,
   FormControl,
@@ -67,6 +68,7 @@ export function GroupForm({
           information: group.information ?? '',
           currency: group.currency ?? '',
           currencyCode: group.currencyCode ?? '',
+          fixedExpenseDateGroups: group.fixedExpenseDateGroups,
           participants: group.participants,
         }
       : {
@@ -74,6 +76,7 @@ export function GroupForm({
           information: '',
           currency: '',
           currencyCode: process.env.NEXT_PUBLIC_DEFAULT_CURRENCY_CODE || 'USD', // TODO: If NEXT_PUBLIC_DEFAULT_CURRENCY_CODE, is not set, determine the default currency code based on locale
+          fixedExpenseDateGroups: false,
           participants: [
             { name: t('Participants.John') },
             { name: t('Participants.Jane') },
@@ -319,6 +322,28 @@ export function GroupForm({
           </CardHeader>
           <CardContent>
             <div className="grid sm:grid-cols-2 gap-4">
+              <FormField
+                control={form.control}
+                name="fixedExpenseDateGroups"
+                render={({ field }) => (
+                  <FormItem className="flex flex-row items-start space-x-3 space-y-0 rounded-md border p-4">
+                    <FormControl>
+                      <Checkbox
+                        checked={field.value}
+                        onCheckedChange={field.onChange}
+                      />
+                    </FormControl>
+                    <div className="space-y-1 leading-none">
+                      <FormLabel>
+                        {t('Settings.FixedExpenseDateGroupsField.label')}
+                      </FormLabel>
+                      <FormDescription>
+                        {t('Settings.FixedExpenseDateGroupsField.description')}
+                      </FormDescription>
+                    </div>
+                  </FormItem>
+                )}
+              />
               {activeUser !== null && (
                 <FormItem>
                   <FormLabel>{t('Settings.ActiveUserField.label')}</FormLabel>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -20,6 +20,7 @@ export async function createGroup(groupFormValues: GroupFormValues) {
       information: groupFormValues.information,
       currency: groupFormValues.currency,
       currencyCode: groupFormValues.currencyCode,
+      fixedExpenseDateGroups: groupFormValues.fixedExpenseDateGroups,
       participants: {
         createMany: {
           data: groupFormValues.participants.map(({ name }) => ({
@@ -301,6 +302,7 @@ export async function updateGroup(
       information: groupFormValues.information,
       currency: groupFormValues.currency,
       currencyCode: groupFormValues.currencyCode,
+      fixedExpenseDateGroups: groupFormValues.fixedExpenseDateGroups,
       participants: {
         deleteMany: existingGroup.participants.filter(
           (p) => !groupFormValues.participants.some((p2) => p2.id === p.id),

--- a/src/lib/expense-date-groups.test.ts
+++ b/src/lib/expense-date-groups.test.ts
@@ -1,0 +1,46 @@
+import { getFixedMonthlyGroupedExpenses } from './expense-date-groups'
+
+describe('getFixedMonthlyGroupedExpenses', () => {
+  const today = new Date(2026, 5, 23)
+
+  it('marks the current month', () => {
+    const groups = getFixedMonthlyGroupedExpenses(
+      [{ expenseDate: new Date(Date.UTC(2026, 5, 10)) }],
+      'en-US',
+      today,
+    )
+
+    expect(groups[0].label).toBe('June - Current Month')
+  })
+
+  it('omits the year for previous months in the current year', () => {
+    const groups = getFixedMonthlyGroupedExpenses(
+      [{ expenseDate: new Date(Date.UTC(2026, 4, 10)) }],
+      'en-US',
+      today,
+    )
+
+    expect(groups[0].label).toBe('May')
+  })
+
+  it('includes the year for months outside the current year', () => {
+    const groups = getFixedMonthlyGroupedExpenses(
+      [{ expenseDate: new Date(Date.UTC(2025, 11, 10)) }],
+      'en-US',
+      today,
+    )
+
+    expect(groups[0].label).toBe('December 2025')
+  })
+
+  it('uses UTC date parts so first-of-month dates do not shift groups', () => {
+    const groups = getFixedMonthlyGroupedExpenses(
+      [{ expenseDate: new Date('2026-06-01T00:00:00.000Z') }],
+      'en-US',
+      today,
+    )
+
+    expect(groups[0].key).toBe('2026-06')
+    expect(groups[0].label).toBe('June - Current Month')
+  })
+})

--- a/src/lib/expense-date-groups.ts
+++ b/src/lib/expense-date-groups.ts
@@ -1,0 +1,119 @@
+import dayjs, { type Dayjs } from 'dayjs'
+
+export const EXPENSE_GROUPS = {
+  UPCOMING: 'upcoming',
+  THIS_WEEK: 'thisWeek',
+  EARLIER_THIS_MONTH: 'earlierThisMonth',
+  LAST_MONTH: 'lastMonth',
+  EARLIER_THIS_YEAR: 'earlierThisYear',
+  LAST_YEAR: 'lastYear',
+  OLDER: 'older',
+} as const
+
+export const EXPENSE_GROUP_KEYS = Object.values(EXPENSE_GROUPS)
+
+export type GroupedExpenses<T> = {
+  key: string
+  label?: string
+  expenses: T[]
+}[]
+
+type ExpenseWithDate = { expenseDate: Date }
+
+function getExpenseGroup(date: Dayjs, today: Dayjs) {
+  if (today.isBefore(date)) {
+    return EXPENSE_GROUPS.UPCOMING
+  } else if (today.isSame(date, 'week')) {
+    return EXPENSE_GROUPS.THIS_WEEK
+  } else if (today.isSame(date, 'month')) {
+    return EXPENSE_GROUPS.EARLIER_THIS_MONTH
+  } else if (today.subtract(1, 'month').isSame(date, 'month')) {
+    return EXPENSE_GROUPS.LAST_MONTH
+  } else if (today.isSame(date, 'year')) {
+    return EXPENSE_GROUPS.EARLIER_THIS_YEAR
+  } else if (today.subtract(1, 'year').isSame(date, 'year')) {
+    return EXPENSE_GROUPS.LAST_YEAR
+  } else {
+    return EXPENSE_GROUPS.OLDER
+  }
+}
+
+export function getRelativeGroupedExpenses<T extends ExpenseWithDate>(
+  expenses: T[],
+  today = dayjs(),
+): GroupedExpenses<T> {
+  const groupedExpenses = expenses.reduce(
+    (result, expense) => {
+      const expenseGroup = getExpenseGroup(dayjs(expense.expenseDate), today)
+      result[expenseGroup] = result[expenseGroup] ?? []
+      result[expenseGroup].push(expense)
+      return result
+    },
+    {} as { [key: string]: T[] },
+  )
+
+  return EXPENSE_GROUP_KEYS.flatMap((key) => {
+    const groupExpenses = groupedExpenses[key]
+    return groupExpenses ? [{ key, expenses: groupExpenses }] : []
+  })
+}
+
+function getUtcYearAndMonth(date: Date) {
+  return {
+    year: date.getUTCFullYear(),
+    month: date.getUTCMonth(),
+  }
+}
+
+function formatMonthLabel(
+  year: number,
+  month: number,
+  locale: string,
+  today: Date,
+  currentMonthLabel: string,
+) {
+  const currentYear = today.getFullYear()
+  const currentMonth = today.getMonth()
+  const labelDate = new Date(year, month)
+  const monthName = labelDate.toLocaleString(locale, { month: 'long' })
+
+  if (year === currentYear && month === currentMonth) {
+    return `${monthName} - ${currentMonthLabel}`
+  }
+  if (year === currentYear) {
+    return monthName
+  }
+  return `${monthName} ${year}`
+}
+
+export function getFixedMonthlyGroupedExpenses<T extends ExpenseWithDate>(
+  expenses: T[],
+  locale: string,
+  today = new Date(),
+  currentMonthLabel = 'Current Month',
+): GroupedExpenses<T> {
+  const groups = new Map<
+    string,
+    { year: number; month: number; expenses: T[] }
+  >()
+
+  for (const expense of expenses) {
+    const { year, month } = getUtcYearAndMonth(expense.expenseDate)
+    const key = `${year}-${String(month + 1).padStart(2, '0')}`
+    const group = groups.get(key) ?? { year, month, expenses: [] }
+    group.expenses.push(expense)
+    groups.set(key, group)
+  }
+
+  return Array.from(groups, ([key, group]) => ({
+    key,
+    label: formatMonthLabel(
+      group.year,
+      group.month,
+      locale,
+      today,
+      currentMonthLabel,
+    ),
+    expenses: group.expenses,
+  }))
+}

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -9,6 +9,7 @@ export const groupFormSchema = z
     information: z.string().optional(),
     currency: z.string().min(1, 'min1').max(5, 'max5'),
     currencyCode: z.union([z.string().length(3).nullish(), z.literal('')]), // ISO-4217 currency code
+    fixedExpenseDateGroups: z.boolean().default(false),
     participants: z
       .array(
         z.object({


### PR DESCRIPTION
Adds a lightweight group-wide setting to group expenses by fixed calendar month instead of relative buckets like “This week” and “Last month”.

- Adds `Group.fixedExpenseDateGroups` with a default of `false`
- Adds a Settings checkbox for calendar-month expense grouping
- Keeps existing relative grouping as the default
- Groups fixed-mode expenses by UTC date parts to avoid DATE timezone shifts
- Adds focused tests for month labels and first-of-month behavior

Verification:
- `npm test`
- `npm run check-types`
- `npm run lint`