### PR TITLE
Add fixed monthly expense grouping setting

### DIFF
--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -38,7 +38,8 @@
       "lastMonth": "Last month",
       "earlierThisYear": "Earlier this year",
       "lastYear": "Last year",
-      "older": "Older"
+      "older": "Older",
+      "currentMonth": "Current Month"
     }
   },
   "ExpenseCard": {
@@ -111,6 +112,14 @@
       "John": "John",
       "Jane": "Jane",
       "Jack": "Jack"
+    },
+    "GroupSettings": {
+      "title": "Group settings",
+      "description": "These settings are shared with everyone who uses this group.",
+      "FixedExpenseDateGroupsField": {
+        "label": "Group expenses by calendar month",
+        "description": "Useful for recurring monthly expenses for roommates and shared bills."
+      }
     },
     "Settings": {
       "title": "Local settings",

--- a/prisma/migrations/20260623120000_add_fixed_expense_date_groups/migration.sql
+++ b/prisma/migrations/20260623120000_add_fixed_expense_date_groups/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "Group" ADD COLUMN "fixedExpenseDateGroups" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,15 +12,16 @@ datasource db {
 }
 
 model Group {
-  id           String        @id
-  name         String
-  information  String?       @db.Text
-  currency     String        @default("$")
-  currencyCode String?
-  participants Participant[]
-  expenses     Expense[]
-  activities   Activity[]
-  createdAt    DateTime      @default(now())
+  id                     String        @id
+  name                   String
+  information            String?       @db.Text
+  currency               String        @default("$")
+  currencyCode           String?
+  fixedExpenseDateGroups Boolean       @default(false)
+  participants           Participant[]
+  expenses               Expense[]
+  activities             Activity[]
+  createdAt              DateTime      @default(now())
 }
 
 model Participant {

--- a/src/app/groups/[groupId]/expenses/expense-list.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-list.tsx
@@ -4,10 +4,13 @@ import { getGroupExpensesAction } from '@/app/groups/[groupId]/expenses/expense-
 import { Button } from '@/components/ui/button'
 import { SearchBar } from '@/components/ui/search-bar'
 import { Skeleton } from '@/components/ui/skeleton'
+import {
+  groupExpensesByCalendarMonth,
+  groupExpensesByRelativeDate,
+} from '@/lib/expense-date-groups'
 import { getCurrencyFromGroup } from '@/lib/utils'
 import { trpc } from '@/trpc/client'
-import dayjs, { type Dayjs } from 'dayjs'
-import { useTranslations } from 'next-intl'
+import { useLocale, useTranslations } from 'next-intl'
 import Link from 'next/link'
 import { forwardRef, useEffect, useMemo, useState } from 'react'
 import { useInView } from 'react-intersection-observer'
@@ -19,44 +22,6 @@ const PAGE_SIZE = 20
 type ExpensesType = NonNullable<
   Awaited<ReturnType<typeof getGroupExpensesAction>>
 >
-
-const EXPENSE_GROUPS = {
-  UPCOMING: 'upcoming',
-  THIS_WEEK: 'thisWeek',
-  EARLIER_THIS_MONTH: 'earlierThisMonth',
-  LAST_MONTH: 'lastMonth',
-  EARLIER_THIS_YEAR: 'earlierThisYear',
-  LAST_YEAR: 'lastYear',
-  OLDER: 'older',
-}
-
-function getExpenseGroup(date: Dayjs, today: Dayjs) {
-  if (today.isBefore(date)) {
-    return EXPENSE_GROUPS.UPCOMING
-  } else if (today.isSame(date, 'week')) {
-    return EXPENSE_GROUPS.THIS_WEEK
-  } else if (today.isSame(date, 'month')) {
-    return EXPENSE_GROUPS.EARLIER_THIS_MONTH
-  } else if (today.subtract(1, 'month').isSame(date, 'month')) {
-    return EXPENSE_GROUPS.LAST_MONTH
-  } else if (today.isSame(date, 'year')) {
-    return EXPENSE_GROUPS.EARLIER_THIS_YEAR
-  } else if (today.subtract(1, 'year').isSame(date, 'year')) {
-    return EXPENSE_GROUPS.LAST_YEAR
-  } else {
-    return EXPENSE_GROUPS.OLDER
-  }
-}
-
-function getGroupedExpensesByDate(expenses: ExpensesType) {
-  const today = dayjs()
-  return expenses.reduce((result: { [key: string]: ExpensesType }, expense) => {
-    const expenseGroup = getExpenseGroup(dayjs(expense.expenseDate), today)
-    result[expenseGroup] = result[expenseGroup] ?? []
-    result[expenseGroup].push(expense)
-    return result
-  }, {})
-}
 
 export function ExpenseList() {
   const { groupId, group } = useCurrentGroup()
@@ -114,6 +79,7 @@ const ExpenseListForSearch = ({
   }, [utils])
 
   const t = useTranslations('Expenses')
+  const locale = useLocale()
   const { ref: loadingRef, inView } = useInView()
 
   const {
@@ -133,10 +99,16 @@ const ExpenseListForSearch = ({
     if (inView && hasMore && !isLoading) fetchNextPage()
   }, [fetchNextPage, hasMore, inView, isLoading])
 
-  const groupedExpensesByDate = useMemo(
-    () => (expenses ? getGroupedExpensesByDate(expenses) : {}),
-    [expenses],
-  )
+  const expenseDateGroups = useMemo(() => {
+    if (!expenses || !group) return []
+    if (group.fixedExpenseDateGroups) {
+      return groupExpensesByCalendarMonth(expenses, {
+        currentMonthLabel: t('Groups.currentMonth'),
+        locale,
+      })
+    }
+    return groupExpensesByRelativeDate(expenses)
+  }, [expenses, group, locale, t])
 
   if (isLoading) return <ExpensesLoading />
 
@@ -154,20 +126,17 @@ const ExpenseListForSearch = ({
 
   return (
     <>
-      {Object.values(EXPENSE_GROUPS).map((expenseGroup: string) => {
-        let groupExpenses = groupedExpensesByDate[expenseGroup]
-        if (!groupExpenses || groupExpenses.length === 0) return null
-
+      {expenseDateGroups.map((expenseGroup) => {
         return (
-          <div key={expenseGroup}>
+          <div key={expenseGroup.key}>
             <div
               className={
                 'text-muted-foreground text-xs pl-4 sm:pl-6 py-1 font-semibold sticky top-16 bg-white dark:bg-[#1b1917]'
               }
             >
-              {t(`Groups.${expenseGroup}`)}
+              {expenseGroup.label ?? t(`Groups.${expenseGroup.key}`)}
             </div>
-            {groupExpenses.map((expense) => (
+            {expenseGroup.expenses.map((expense) => (
               <ExpenseCard
                 key={expense.id}
                 expense={expense}

--- a/src/components/group-form.tsx
+++ b/src/components/group-form.tsx
@@ -8,6 +8,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
+import { Checkbox } from '@/components/ui/checkbox'
 import {
   Form,
   FormControl,
@@ -67,6 +68,7 @@ export function GroupForm({
           information: group.information ?? '',
           currency: group.currency ?? '',
           currencyCode: group.currencyCode ?? '',
+          fixedExpenseDateGroups: group.fixedExpenseDateGroups,
           participants: group.participants,
         }
       : {
@@ -74,6 +76,7 @@ export function GroupForm({
           information: '',
           currency: '',
           currencyCode: process.env.NEXT_PUBLIC_DEFAULT_CURRENCY_CODE || 'USD', // TODO: If NEXT_PUBLIC_DEFAULT_CURRENCY_CODE, is not set, determine the default currency code based on locale
+          fixedExpenseDateGroups: false,
           participants: [
             { name: t('Participants.John') },
             { name: t('Participants.Jane') },
@@ -310,6 +313,41 @@ export function GroupForm({
               {t('Participants.add')}
             </Button>
           </CardFooter>
+        </Card>
+
+        <Card className="mb-4">
+          <CardHeader>
+            <CardTitle>{t('GroupSettings.title')}</CardTitle>
+            <CardDescription>{t('GroupSettings.description')}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <FormField
+              control={form.control}
+              name="fixedExpenseDateGroups"
+              render={({ field }) => (
+                <FormItem className="flex flex-row items-start space-x-3 space-y-0">
+                  <FormControl>
+                    <Checkbox
+                      checked={field.value}
+                      onCheckedChange={(checked) =>
+                        field.onChange(checked === true)
+                      }
+                    />
+                  </FormControl>
+                  <div className="space-y-1 leading-none">
+                    <FormLabel>
+                      {t('GroupSettings.FixedExpenseDateGroupsField.label')}
+                    </FormLabel>
+                    <FormDescription>
+                      {t(
+                        'GroupSettings.FixedExpenseDateGroupsField.description',
+                      )}
+                    </FormDescription>
+                  </div>
+                </FormItem>
+              )}
+            />
+          </CardContent>
         </Card>
 
         <Card className="mb-4">

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -20,6 +20,7 @@ export async function createGroup(groupFormValues: GroupFormValues) {
       information: groupFormValues.information,
       currency: groupFormValues.currency,
       currencyCode: groupFormValues.currencyCode,
+      fixedExpenseDateGroups: groupFormValues.fixedExpenseDateGroups,
       participants: {
         createMany: {
           data: groupFormValues.participants.map(({ name }) => ({
@@ -301,6 +302,7 @@ export async function updateGroup(
       information: groupFormValues.information,
       currency: groupFormValues.currency,
       currencyCode: groupFormValues.currencyCode,
+      fixedExpenseDateGroups: groupFormValues.fixedExpenseDateGroups,
       participants: {
         deleteMany: existingGroup.participants.filter(
           (p) => !groupFormValues.participants.some((p2) => p2.id === p.id),

--- a/src/lib/expense-date-groups.test.ts
+++ b/src/lib/expense-date-groups.test.ts
@@ -1,0 +1,50 @@
+import { groupExpensesByCalendarMonth } from './expense-date-groups'
+
+const options = {
+  currentMonthLabel: 'Current Month',
+  locale: 'en-US',
+  now: new Date('2026-06-15T12:00:00.000Z'),
+}
+
+function expense(expenseDate: string) {
+  return { expenseDate: new Date(expenseDate) }
+}
+
+describe('groupExpensesByCalendarMonth', () => {
+  it('includes the current month suffix for the current month', () => {
+    const groups = groupExpensesByCalendarMonth(
+      [expense('2026-06-15T00:00:00.000Z')],
+      options,
+    )
+
+    expect(groups[0]?.label).toBe('June - Current Month')
+  })
+
+  it('omits the year for a previous month in the same year', () => {
+    const groups = groupExpensesByCalendarMonth(
+      [expense('2026-05-15T00:00:00.000Z')],
+      options,
+    )
+
+    expect(groups[0]?.label).toBe('May')
+  })
+
+  it('includes the year for a month outside the current year', () => {
+    const groups = groupExpensesByCalendarMonth(
+      [expense('2025-12-15T00:00:00.000Z')],
+      options,
+    )
+
+    expect(groups[0]?.label).toBe('December 2025')
+  })
+
+  it('uses UTC date parts when assigning expenses to a month', () => {
+    const groups = groupExpensesByCalendarMonth(
+      [expense('2026-06-01T00:00:00.000Z')],
+      options,
+    )
+
+    expect(groups[0]?.key).toBe('2026-06')
+    expect(groups[0]?.label).toBe('June - Current Month')
+  })
+})

--- a/src/lib/expense-date-groups.ts
+++ b/src/lib/expense-date-groups.ts
@@ -1,0 +1,108 @@
+import dayjs, { type Dayjs } from 'dayjs'
+
+export const RELATIVE_EXPENSE_DATE_GROUPS = {
+  UPCOMING: 'upcoming',
+  THIS_WEEK: 'thisWeek',
+  EARLIER_THIS_MONTH: 'earlierThisMonth',
+  LAST_MONTH: 'lastMonth',
+  EARLIER_THIS_YEAR: 'earlierThisYear',
+  LAST_YEAR: 'lastYear',
+  OLDER: 'older',
+} as const
+
+export type ExpenseWithDate = {
+  expenseDate: Date
+}
+
+export type ExpenseDateGroup<TExpense extends ExpenseWithDate> = {
+  key: string
+  label?: string
+  expenses: TExpense[]
+}
+
+const RELATIVE_EXPENSE_DATE_GROUP_ORDER = Object.values(
+  RELATIVE_EXPENSE_DATE_GROUPS,
+)
+
+function getRelativeExpenseDateGroup(date: Dayjs, today: Dayjs) {
+  if (today.isBefore(date)) {
+    return RELATIVE_EXPENSE_DATE_GROUPS.UPCOMING
+  } else if (today.isSame(date, 'week')) {
+    return RELATIVE_EXPENSE_DATE_GROUPS.THIS_WEEK
+  } else if (today.isSame(date, 'month')) {
+    return RELATIVE_EXPENSE_DATE_GROUPS.EARLIER_THIS_MONTH
+  } else if (today.subtract(1, 'month').isSame(date, 'month')) {
+    return RELATIVE_EXPENSE_DATE_GROUPS.LAST_MONTH
+  } else if (today.isSame(date, 'year')) {
+    return RELATIVE_EXPENSE_DATE_GROUPS.EARLIER_THIS_YEAR
+  } else if (today.subtract(1, 'year').isSame(date, 'year')) {
+    return RELATIVE_EXPENSE_DATE_GROUPS.LAST_YEAR
+  } else {
+    return RELATIVE_EXPENSE_DATE_GROUPS.OLDER
+  }
+}
+
+export function groupExpensesByRelativeDate<TExpense extends ExpenseWithDate>(
+  expenses: TExpense[],
+  today: Dayjs = dayjs(),
+): ExpenseDateGroup<TExpense>[] {
+  const groupedExpenses = expenses.reduce(
+    (result, expense) => {
+      const expenseGroup = getRelativeExpenseDateGroup(
+        dayjs(expense.expenseDate),
+        today,
+      )
+      result[expenseGroup] = result[expenseGroup] ?? []
+      result[expenseGroup].push(expense)
+      return result
+    },
+    {} as Record<string, TExpense[]>,
+  )
+
+  return RELATIVE_EXPENSE_DATE_GROUP_ORDER.flatMap((key) => {
+    const groupExpenses = groupedExpenses[key]
+    if (!groupExpenses || groupExpenses.length === 0) return []
+    return [{ key, expenses: groupExpenses }]
+  })
+}
+
+export function groupExpensesByCalendarMonth<TExpense extends ExpenseWithDate>(
+  expenses: TExpense[],
+  options: {
+    currentMonthLabel: string
+    locale: string
+    now?: Date
+  },
+): ExpenseDateGroup<TExpense>[] {
+  const now = options.now ?? new Date()
+  const currentYear = now.getUTCFullYear()
+  const currentMonth = now.getUTCMonth()
+  const monthFormatter = new Intl.DateTimeFormat(options.locale, {
+    month: 'long',
+    timeZone: 'UTC',
+  })
+  const groups = new Map<string, ExpenseDateGroup<TExpense>>()
+
+  for (const expense of expenses) {
+    const expenseYear = expense.expenseDate.getUTCFullYear()
+    const expenseMonth = expense.expenseDate.getUTCMonth()
+    const key = `${expenseYear}-${String(expenseMonth + 1).padStart(2, '0')}`
+    const monthLabel = monthFormatter.format(
+      new Date(Date.UTC(expenseYear, expenseMonth, 1)),
+    )
+    const label =
+      expenseYear === currentYear && expenseMonth === currentMonth
+        ? `${monthLabel} - ${options.currentMonthLabel}`
+        : expenseYear === currentYear
+        ? monthLabel
+        : `${monthLabel} ${expenseYear}`
+
+    if (!groups.has(key)) {
+      groups.set(key, { key, label, expenses: [] })
+    }
+
+    groups.get(key)?.expenses.push(expense)
+  }
+
+  return Array.from(groups.values())
+}

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -9,6 +9,7 @@ export const groupFormSchema = z
     information: z.string().optional(),
     currency: z.string().min(1, 'min1').max(5, 'max5'),
     currencyCode: z.union([z.string().length(3).nullish(), z.literal('')]), // ISO-4217 currency code
+    fixedExpenseDateGroups: z.boolean().default(false),
     participants: z
       .array(
         z.object({


### PR DESCRIPTION
## Summary

Adds an opt-in group-wide setting to display expense date headers as fixed calendar-month buckets instead of the existing relative buckets.

By default, groups continue using the current behavior with labels like “This week”, “Earlier this month”, and “Last month”. When enabled, expenses are grouped by calendar month, which is more useful for recurring monthly expenses, roommates, and shared bills.

## Changes

- Added `fixedExpenseDateGroups` to `Group` with a default of `false`
- Added a Prisma migration for the new field
- Added a separate “Group settings” section in the group form
- Kept the existing “Local settings” section and Active user selector unchanged
- Extracted expense date grouping into a small helper module
- Added fixed calendar-month grouping using UTC date parts from `expense.expenseDate`
- Kept relative grouping behavior unchanged when the setting is disabled
- Added tests for fixed monthly labels and UTC month handling

## Testing

- `npm test`
- `npm run check-types`
- `npm run lint`
- Targeted Prettier check on touched files

## Transparency Note

This is my first request using Codex 5.5 at highest enterprise setting for implementation help. I’m trying it out and I want to be transparent so reviewers can flag anything that feels off or low-quality.